### PR TITLE
Make uncompress return the resulting data

### DIFF
--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -118,6 +118,7 @@ const uncompress = (data) => {
     emoji.search = buildSearch(emoji)
   }
   data = deepFreeze(data)
+  return data
 }
 
 module.exports = { buildSearch, compress, uncompress }


### PR DESCRIPTION
Fix for the https://github.com/serebrov/emoji-mart-vue/pull/3, make uncompress return the data, it feels more natural, so we can avoid data = uncompress(data) or functoin(uncompress(data)) issues.
Also we are free to change `uncompress` to avoid mutating original data if we'll need it.