### PR TITLE
Use css to set emoji size and background.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,11 @@ import { Picker } from 'emoji-mart-vue'
 | **exclude** | | `[]` | Don't load excluded categories. Accepts [I18n categories keys](#i18n). |
 | **custom** | | `[]` | [Custom emojis](#custom-emojis) |
 | **recent** | | | Pass your own frequently used emojis as array of string IDs |
-| **emojiSize** | | `24` | The emoji width and height |
+| **emojiSize** | | `24` | The emoji width and height to calculate picker size; set the size for emoji itself via CSS |
 | **perLine** | | `9` | Number of emojis per line. While there’s no minimum or maximum, this will affect the picker’s width. This will set *Frequently Used* length as well (`perLine * 4`) |
 | **i18n** | | [`{…}`](#i18n) | [An object](#i18n) containing localized strings |
 | **native** | | `false` | Renders the native unicode emoji |
 | **set** | | `apple` | The emoji set: `'apple', 'google', 'twitter', 'emojione', 'messenger', 'facebook'` |
-| **sheetSize** | | `64` | The emoji [sheet size](#sheet-sizes): `16, 20, 32, 64` |
-| **backgroundImageFn** | | ```((set, sheetSize) => …)``` | A Fn that returns that image sheet to use for emojis. Useful for avoiding a request if you have the sheet locally. |
 | **emojisToShowFilter** | | ```((emoji) => true)``` | A Fn to choose whether an emoji should be displayed or not |
 | **showPreview** | | `true` | Display preview section |
 | **showSearch** | | `true` | Display search section |

--- a/src/components/category.vue
+++ b/src/components/category.vue
@@ -20,13 +20,10 @@
   <div v-if="!hasResults">
     <nimble-emoji
       :data="data"
-      :size="emojiProps.size"
       emoji="sleuth_or_spy"
       :native="emojiProps.native"
       :skin="emojiProps.skin"
       :set="emojiProps.set"
-      :sheet-size="emojiProps.sheetSize"
-      :background-image-fn="emojiProps.backgroundImageFn"
     />
     <div class="emoji-mart-no-results-label">{{ i18n.notfound }}</div>
   </div>
@@ -45,10 +42,7 @@
     :native="emojiProps.native"
     :skin="emojiProps.skin"
     :set="emojiProps.set"
-    :size="emojiProps.size"
-    :sheet-size="emojiProps.sheetSize"
     :tooltip="emojiProps.tooltip"
-    :background-image-fn="emojiProps.backgroundImageFn"
     @click="emojiProps.onClick"
     @mouseenter="emojiProps.onEnter"
     @mouseleave="emojiProps.onLeave"
@@ -101,9 +95,8 @@ export default {
             emoji, this.emojiProps.skin, this.emojiProps.set, this.data)
           let emojiView = new EmojiView(
             emojiObject, this.emojiProps.set, this.emojiProps.native, 
-            this.emojiProps.fallback, this.emojiProps.size, 
-            this.emojiProps.sheetSize, 
-            this.emojiProps.backgroundImageFn)
+            this.emojiProps.fallback
+          )
           return { emojiObject, emojiView }
       })
     }
@@ -111,8 +104,8 @@ export default {
   methods: {
     emojiView(emoji) {
       return new EmojiView(
-          this.set, this.native, this.fallback,
-          this.size, this.sheetSize, this.backgroundImageFn)
+          this.set, this.native, this.fallback
+      )
     },
   },
   components: {

--- a/src/components/emoji/nimbleEmoji.vue
+++ b/src/components/emoji/nimbleEmoji.vue
@@ -25,8 +25,8 @@ export default {
   computed: {
     view() {
       return new EmojiView(
-          this.emoji, this.set, this.native, this.fallback,
-          this.size, this.sheetSize, this.backgroundImageFn)
+          this.emoji, this.set, this.native, this.fallback
+      )
     },
     emojiData() {
       return this.emoji._data
@@ -59,6 +59,43 @@ export default {
   position: relative;
   display: inline-block;
   font-size: 0;
+}
+
+.emoji-mart-emoji span {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+}
+
+.emoji-mart-preview-emoji .emoji-mart-emoji span {
+  width: 38px;
+  height: 38px;
+}
+
+.emoji-mart-emoji-type-native {
+  font-size: 18px;
+}
+
+.emoji-mart-emoji-type-image {
+  background-size: 5200%;
+}
+.emoji-mart-emoji-type-image.emoji-mart-emoji-set-emojione {
+  background-image: url("https://unpkg.com/emoji-datasource-emojione@4.0.4/img/emojione/sheets-256/64.png");
+}
+.emoji-mart-emoji-type-image.emoji-mart-emoji-set-messenger {
+  background-image: url("https://unpkg.com/emoji-datasource-messenger@4.0.4/img/emojione/sheets-256/64.png");
+}
+.emoji-mart-emoji-type-image.emoji-mart-emoji-set-apple {
+  background-image: url("https://unpkg.com/emoji-datasource-apple@4.0.4/img/emojione/sheets-256/64.png");
+}
+.emoji-mart-emoji-type-image.emoji-mart-emoji-set-facebook {
+  background-image: url("https://unpkg.com/emoji-datasource-facebook@4.0.4/img/emojione/sheets-256/64.png");
+}
+.emoji-mart-emoji-type-image.emoji-mart-emoji-set-google {
+  background-image: url("https://unpkg.com/emoji-datasource-google@4.0.4/img/emojione/sheets-256/64.png");
+}
+.emoji-mart-emoji-type-image.emoji-mart-emoji-set-twitter {
+  background-image: url("https://unpkg.com/emoji-datasource-twitter@4.0.4/img/emojione/sheets-256/64.png");
 }
 
 </style>

--- a/src/components/picker/nimblePicker.vue
+++ b/src/components/picker/nimblePicker.vue
@@ -157,11 +157,8 @@ export default {
       return {
         native: this.native,
         skin: this.activeSkin,
-        size: this.emojiSize,
         set: this.set,
-        sheetSize: this.sheetSize,
         tooltip: this.emojiTooltip,
-        backgroundImageFn: this.backgroundImageFn,
         onEnter: this.onEmojiEnter.bind(this),
         onLeave: this.onEmojiLeave.bind(this),
         onClick: this.onEmojiClick.bind(this)

--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -9,9 +9,6 @@
         :native="emojiProps.native"
         :skin="emojiProps.skin"
         :set="emojiProps.set"
-        :size="38"
-        :sheet-size="emojiProps.sheetSize"
-        :background-image-fn="emojiProps.backgroundImageFn"
       />
     </div>
 
@@ -34,9 +31,6 @@
         :native="emojiProps.native"
         :skin="emojiProps.skin"
         :set="emojiProps.set"
-        :size="38"
-        :sheet-size="emojiProps.sheetSize"
-        :background-image-fn="emojiProps.backgroundImageFn"
       />
     </div>
 

--- a/src/utils/emoji-data.js
+++ b/src/utils/emoji-data.js
@@ -31,23 +31,12 @@ export class EmojiView {
    * set - string, emoji set name
    * native - boolean, whether to render native emoji
    * fallback - fallback function to render missing emoji, optional
-   * size - integer, emoji size
-   * sheetSize - integer, 16, 20, 32, 64 - emoji image sheet size
-   * backgroundImageFn - function to get background image url
    */
-  constructor(
-    emoji, set, native, fallback,
-    size, sheetSize, backgroundImageFn
-  ) {
+  constructor(emoji, set, native, fallback) {
     this._emoji = emoji
     this._native = native
     this._set = set
     this._fallback = fallback
-    this._size = size
-    this._sheetSize = sheetSize
-    this._backgroundImageFn = backgroundImageFn || function(set, sheetSize) {
-      return `https://unpkg.com/emoji-datasource-${set}@${EMOJI_DATASOURCE_VERSION}/img/${set}/sheets-256/${sheetSize}.png`
-    }
   }
 
   canRender() {
@@ -81,7 +70,6 @@ export class EmojiView {
 
   cssClass() {
     return [
-      // 'emoji-mart-emoji',
       'emoji-mart-emoji-set-' + this._set,
       'emoji-mart-emoji-type-' + this.emojiType()
     ]
@@ -90,32 +78,16 @@ export class EmojiView {
   cssStyle() {
     if (this.isCustom()) {
       return {
-        display: 'inline-block',
-        width: this._size + 'px',
-        height: this._size + 'px',
         backgroundImage: 'url(' + this._emoji._data.imageUrl + ')',
         backgroundSize: '100%',
       }
     }
-    if (this.isNative()) {
-      let styles = { 
-        fontSize: this._size - 6 + 'px',
-        display: 'inline-block',
-        width: this._size + 'px',
-        height: this._size + 'px'
-      }
-      return styles
-    }
     if (this.hasEmoji()) {
       return {
-        display: 'inline-block',
-        width: this._size + 'px',
-        height: this._size + 'px',
-        backgroundImage: 'url(' + this._backgroundImageFn(this._set, this._sheetSize) + ')',
-        backgroundSize: (100 * SHEET_COLUMNS) + '%',
         backgroundPosition: this._emoji.getPosition()
       }
     }
+    return {}
   }
 
   content() {

--- a/src/utils/shared-props.js
+++ b/src/utils/shared-props.js
@@ -1,10 +1,4 @@
 const EmojiProps = {
-  backgroundImageFn: {
-    type: Function,
-    default: function(set, sheetSize) {
-      return `https://unpkg.com/emoji-datasource-${set}@${EMOJI_DATASOURCE_VERSION}/img/${set}/sheets-256/${sheetSize}.png`
-    }
-  },
   native: {
     type: Boolean,
     default: false
@@ -20,17 +14,9 @@ const EmojiProps = {
     type: Number,
     default: 1
   },
-  sheetSize: {
-    type: Number,
-    default: 64
-  },
   set: {
     type: String,
     default: 'apple'
-  },
-  size: {
-    type: Number,
-    default: 24
   },
   emoji: {
     type: [String, Object],
@@ -74,13 +60,6 @@ const PickerProps = {
   native: {
     type: Boolean,
     default: false
-  },
-  backgroundImageFn: {
-    type: Function
-  },
-  sheetSize: {
-    type: Number,
-    default: 64
   },
   emojisToShowFilter: {
     type: Function


### PR DESCRIPTION
Making it in javascript adds a slowdown (we have a lot of emojis and inline styles increase amount of HTML noticeably).
The default properties can be overwritten via css.