### PR TITLE
Remove getSanitizedData function.

### DIFF
--- a/src/utils/emoji-data.js
+++ b/src/utils/emoji-data.js
@@ -6,8 +6,7 @@ export class EmojiData {
 
   constructor(emoji, skin, set, data) {
     this._key = emoji
-    this._data = Object.assign({}, getData(
-        emoji, skin, set, data))
+    this._data = getData(emoji, skin, set, data)
     this._sanitized = sanitize(this._data)
     for (let key in this._sanitized) {
       this[key] = this._sanitized[key]

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -53,10 +53,6 @@ function sanitize(emoji) {
   }
 }
 
-function getSanitizedData() {
-  return sanitize(getData(...arguments))
-}
-
 function cloneEmoji(emoji) {
   if (typeof emoji === 'string') {
     return emoji;
@@ -201,7 +197,6 @@ function measureScrollbar() {
 
 export {
   getData,
-  getSanitizedData,
   sanitize,
   uniq,
   intersect,

--- a/src/utils/nimble-emoji-index.js
+++ b/src/utils/nimble-emoji-index.js
@@ -1,4 +1,4 @@
-import { getData, getSanitizedData, intersect } from './index'
+import { getData, sanitize, intersect } from './index'
 
 export default class NimbleEmojiIndex {
   constructor(data) {
@@ -28,7 +28,8 @@ export default class NimbleEmojiIndex {
         })
       }
 
-      this.emojis[id] = getSanitizedData(id, null, null, this.data)
+      let data = getData(id, null, null, this.data)
+      this.emojis[id] = sanitize(data)
       this.originalPool[id] = emojiData
     }
   }
@@ -50,7 +51,7 @@ export default class NimbleEmojiIndex {
 
       if (emojiId && !pool[emojiId]) {
         pool[emojiId] = getData(emoji, null, null, this.data)
-        this.emojis[emojiId] = getSanitizedData(emoji, null, null, this.data)
+        this.emojis[emojiId] = getSanitizedData(pool[emojiId])
       }
     })
 


### PR DESCRIPTION
It hides the fact that there is a (quite complex) getData call behind it, so we have code like this:

    pool[emojiId] = getData(emoji, null, null, this.data)
    this.emojis[emojiId] = getSanitizedData(emoji, null, null, this.data)

It is not obvious, but we actually call getData twice here. Now this is changed to

    pool[emojiId] = getData(emoji, null, null, this.data)
    this.emojis[emojiId] = getSanitizedData(pool[emojiId])

And, since, there is no getSanitizedData anymore, we guarantee that no such error will be made in the future.