### PR TITLE
Re-enable emojiSize property

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Note: CSS also includes background images for image-based emoji sets (apple, goo
 | **autoFocus**      |          | `false`            | Auto focus the search input when mounted                                                             |
 | **color**          |          | `#ae65c5`          | The top bar anchors select and hover color                                                           |
 | **emoji**          |          | `department_store` | The emoji shown when no emojis are hovered, set to an empty string to show nothing                   |
-| **emojiSize**      |          | `24`               | The emoji width and height; also affects font size for native emoji (it is 80% of emojiSize); also the picker width is cacluated dynamically based on emojiSize |
+| **emojiSize**      |          | `24`               | The emoji width and height; affects font size for native emoji (it is 80% of emojiSize); also the picker width is cacluated dynamically based on emojiSize |
 | **perLine**        |          | `9`                | Number of emojis per line. While there’s no minimum or maximum, this will affect the picker’s width. |
 | **i18n**           |          | [`{…}`](#i18n)     | [An object](#i18n) containing localized strings                                                      |
 | **native**         |          | `false`            | Renders the native unicode emoji                                                                     |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Note: CSS also includes background images for image-based emoji sets (apple, goo
 | **autoFocus**      |          | `false`            | Auto focus the search input when mounted                                                             |
 | **color**          |          | `#ae65c5`          | The top bar anchors select and hover color                                                           |
 | **emoji**          |          | `department_store` | The emoji shown when no emojis are hovered, set to an empty string to show nothing                   |
-| **emojiSize**      |          | `24`               | The emoji width and height to calculate picker size; set the size for emoji itself via CSS           |
+| **emojiSize**      |          | `24`               | The emoji width and height; also affects font size for native emoji (it is 80% of emojiSize); also the picker width is cacluated dynamically based on emojiSize |
 | **perLine**        |          | `9`                | Number of emojis per line. While there’s no minimum or maximum, this will affect the picker’s width. |
 | **i18n**           |          | [`{…}`](#i18n)     | [An object](#i18n) containing localized strings                                                      |
 | **native**         |          | `false`            | Renders the native unicode emoji                                                                     |

--- a/css/emoji-mart.css
+++ b/css/emoji-mart.css
@@ -26,8 +26,6 @@
 
 .emoji-mart .emoji-mart-emoji span {
   display: inline-block;
-  width: 24px;
-  height: 24px;
 }
 
 .emoji-mart .emoji-mart-preview-emoji .emoji-mart-emoji span {
@@ -37,7 +35,6 @@
 }
 
 .emoji-mart .emoji-type-native {
-  font-size: 18px;
   font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Segoe UI", "Apple Color Emoji", "Twemoji Mozilla", "Noto Color Emoji", "EmojiOne Color", "Android Emoji";
   word-break: keep-all;
 }

--- a/docs/app.vue
+++ b/docs/app.vue
@@ -74,7 +74,7 @@
 
   <div class="row">
     <div>Filtered picker example</div>
-    <NimblePicker :native="true" emoji="flag-tf" :data="indexFiltered"/>
+    <NimblePicker :native="true" emoji="flag-tf" :emojiSize="18" :data="indexFiltered"/>
   </div>
 </div>
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,13 @@
     "moduleNameMapper": {
       ".+\\.css$": "<rootDir>/spec/css-stub.js"
     },
-    "transformIgnorePatterns": ["^.+\\.css$", "<rootDir>/node_modules/"]
+    "transformIgnorePatterns": ["^.+\\.css$", "<rootDir>/node_modules/"],
+    "collectCoverageFrom": [
+      "src/**",
+      "!src/vendor/**",
+      "!src/polyfills/**",
+      "!src/webpack.config.js"
+    ]
   },
   "size-limit": [
     {

--- a/spec/__snapshots__/picker-spec.js.snap
+++ b/spec/__snapshots__/picker-spec.js.snap
@@ -274,7 +274,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 96.07843137254902%;"
+                style="background-position: 27.45% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -285,7 +285,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 47.05882352941176%;"
+                style="background-position: 58.82% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -296,7 +296,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 94.11764705882352%;"
+                style="background-position: 58.82% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -307,7 +307,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 72.54901960784314%;"
+                style="background-position: 58.82% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -318,7 +318,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 58.8235294117647%;"
+                style="background-position: 58.82% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -329,7 +329,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 0%;"
+                style="background-position: 60.78% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -340,7 +340,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 56.86274509803921%;"
+                style="background-position: 58.82% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -351,7 +351,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 50.98039215686274%;"
+                style="background-position: 58.82% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -362,7 +362,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 41.17647058823529%;"
+                style="background-position: 60.78% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -373,7 +373,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 3.9215686274509802%;"
+                style="background-position: 60.78% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -384,7 +384,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 82.35294117647058%;"
+                style="background-position: 58.82% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -395,7 +395,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 25.49019607843137%;"
+                style="background-position: 60.78% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -406,7 +406,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 33.33333333333333%;"
+                style="background-position: 60.78% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -417,7 +417,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 74.50980392156862%;"
+                style="background-position: 58.82% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -428,7 +428,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 98.0392156862745% 15.686274509803921%;"
+                style="background-position: 98.04% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -439,7 +439,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 29.41176470588235%;"
+                style="background-position: 49.02% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -473,7 +473,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 47.05882352941176%;"
+                style="background-position: 58.82% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -484,7 +484,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 49.01960784313725%;"
+                style="background-position: 58.82% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -495,7 +495,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 50.98039215686274%;"
+                style="background-position: 58.82% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -506,7 +506,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 50.98039215686274%;"
+                style="background-position: 74.51% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -517,7 +517,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 52.94117647058823%;"
+                style="background-position: 58.82% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -528,7 +528,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 54.90196078431372%;"
+                style="background-position: 58.82% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -539,7 +539,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 56.86274509803921%;"
+                style="background-position: 58.82% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -550,7 +550,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 58.8235294117647%;"
+                style="background-position: 58.82% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -561,7 +561,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 64.70588235294117%;"
+                style="background-position: 58.82% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -572,7 +572,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 66.66666666666666%;"
+                style="background-position: 58.82% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -583,7 +583,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 68.62745098039215%;"
+                style="background-position: 58.82% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -594,7 +594,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 74.50980392156862%;"
+                style="background-position: 58.82% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -605,7 +605,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 72.54901960784314%;"
+                style="background-position: 58.82% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -616,7 +616,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 94.11764705882352%;"
+                style="background-position: 58.82% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -627,7 +627,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 92.15686274509804%;"
+                style="background-position: 58.82% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -638,7 +638,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 96.07843137254902%;"
+                style="background-position: 58.82% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -649,7 +649,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 98.0392156862745%;"
+                style="background-position: 58.82% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -660,7 +660,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.15686274509804% 80.3921568627451%;"
+                style="background-position: 92.16% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -671,7 +671,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 74.50980392156862%;"
+                style="background-position: 60.78% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -682,7 +682,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 60.78431372549019%;"
+                style="background-position: 72.55% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -693,7 +693,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 96.07843137254902%;"
+                style="background-position: 74.51% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -704,7 +704,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 54.90196078431372%;"
+                style="background-position: 72.55% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -715,7 +715,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 94.11764705882352%;"
+                style="background-position: 74.51% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -726,7 +726,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 78.4313725490196%;"
+                style="background-position: 58.82% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -737,7 +737,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 80.3921568627451%;"
+                style="background-position: 58.82% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -748,7 +748,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 50.98039215686274%;"
+                style="background-position: 60.78% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -759,7 +759,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 78.4313725490196%;"
+                style="background-position: 60.78% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -770,7 +770,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 76.47058823529412%;"
+                style="background-position: 58.82% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -781,7 +781,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 13.72549019607843%;"
+                style="background-position: 60.78% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -792,7 +792,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 17.64705882352941%;"
+                style="background-position: 60.78% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -803,7 +803,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 35.29411764705882%;"
+                style="background-position: 60.78% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -814,7 +814,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 47.05882352941176%;"
+                style="background-position: 72.55% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -825,7 +825,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 37.25490196078431%;"
+                style="background-position: 60.78% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -836,7 +836,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 27.45098039215686%;"
+                style="background-position: 60.78% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -847,7 +847,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 29.41176470588235%;"
+                style="background-position: 60.78% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -858,7 +858,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 47.05882352941176%;"
+                style="background-position: 60.78% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -869,7 +869,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 70.58823529411764%;"
+                style="background-position: 58.82% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -880,7 +880,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 100%;"
+                style="background-position: 58.82% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -891,7 +891,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 0%;"
+                style="background-position: 60.78% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -902,7 +902,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 1.9607843137254901%;"
+                style="background-position: 60.78% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -913,7 +913,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 52.94117647058823%;"
+                style="background-position: 74.51% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -924,7 +924,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 82.35294117647058%;"
+                style="background-position: 58.82% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -935,7 +935,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 84.31372549019608%;"
+                style="background-position: 58.82% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -946,7 +946,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 86.27450980392156%;"
+                style="background-position: 58.82% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -957,7 +957,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 88.23529411764706%;"
+                style="background-position: 58.82% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -968,7 +968,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 76.47058823529412%;"
+                style="background-position: 60.78% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -979,7 +979,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 49.01960784313725%;"
+                style="background-position: 72.55% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -990,7 +990,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 43.13725490196078%;"
+                style="background-position: 60.78% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1001,7 +1001,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.15686274509804% 78.4313725490196%;"
+                style="background-position: 92.16% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1012,7 +1012,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 72.54901960784314%;"
+                style="background-position: 60.78% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1023,7 +1023,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 90.19607843137254%;"
+                style="background-position: 58.82% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1034,7 +1034,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 3.9215686274509802%;"
+                style="background-position: 60.78% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1045,7 +1045,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 5.88235294117647%;"
+                style="background-position: 60.78% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1056,7 +1056,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 15.686274509803921%;"
+                style="background-position: 60.78% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1067,7 +1067,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 11.76470588235294%;"
+                style="background-position: 60.78% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1078,7 +1078,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 33.33333333333333%;"
+                style="background-position: 60.78% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1089,7 +1089,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 19.6078431372549%;"
+                style="background-position: 60.78% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1100,7 +1100,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 21.56862745098039%;"
+                style="background-position: 60.78% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1111,7 +1111,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 23.52941176470588%;"
+                style="background-position: 60.78% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1122,7 +1122,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 25.49019607843137%;"
+                style="background-position: 60.78% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1133,7 +1133,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 5.88235294117647%;"
+                style="background-position: 76.47% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1144,7 +1144,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 31.372549019607842%;"
+                style="background-position: 60.78% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1155,7 +1155,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 39.2156862745098%;"
+                style="background-position: 60.78% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1166,7 +1166,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 41.17647058823529%;"
+                style="background-position: 60.78% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1177,7 +1177,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 45.09803921568627%;"
+                style="background-position: 60.78% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1188,7 +1188,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 98.0392156862745%;"
+                style="background-position: 74.51% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1199,7 +1199,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 49.01960784313725%;"
+                style="background-position: 60.78% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1210,7 +1210,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 9.80392156862745%;"
+                style="background-position: 60.78% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1221,7 +1221,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 7.8431372549019605%;"
+                style="background-position: 60.78% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1232,7 +1232,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 0%;"
+                style="background-position: 76.47% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1243,7 +1243,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 52.94117647058823%;"
+                style="background-position: 60.78% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1254,7 +1254,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 50.98039215686274%;"
+                style="background-position: 72.55% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1265,7 +1265,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 56.86274509803921%;"
+                style="background-position: 72.55% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1276,7 +1276,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 49.01960784313725%;"
+                style="background-position: 74.51% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1287,7 +1287,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 3.9215686274509802%;"
+                style="background-position: 76.47% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1298,7 +1298,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 92.15686274509804%;"
+                style="background-position: 74.51% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1309,7 +1309,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 60.78431372549019%;"
+                style="background-position: 58.82% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1320,7 +1320,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 45.09803921568627%;"
+                style="background-position: 74.51% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1331,7 +1331,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 47.05882352941176%;"
+                style="background-position: 74.51% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1342,7 +1342,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 54.90196078431372%;"
+                style="background-position: 74.51% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1353,7 +1353,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 100%;"
+                style="background-position: 74.51% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1364,7 +1364,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 1.9607843137254901%;"
+                style="background-position: 76.47% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1375,7 +1375,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 96.07843137254902%;"
+                style="background-position: 82.35% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1386,7 +1386,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 52.94117647058823%;"
+                style="background-position: 72.55% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1397,7 +1397,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 62.745098039215684%;"
+                style="background-position: 58.82% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1408,7 +1408,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 100%;"
+                style="background-position: 43.14% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1419,7 +1419,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 78.4313725490196%;"
+                style="background-position: 43.14% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1430,7 +1430,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 80.3921568627451%;"
+                style="background-position: 43.14% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1441,7 +1441,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 0%;"
+                style="background-position: 45.1% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1452,7 +1452,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.15686274509804% 62.745098039215684%;"
+                style="background-position: 92.16% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1463,7 +1463,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 82.35294117647058%;"
+                style="background-position: 43.14% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1474,7 +1474,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 96.07843137254902%;"
+                style="background-position: 43.14% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1485,7 +1485,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 98.0392156862745%;"
+                style="background-position: 43.14% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1496,7 +1496,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 58.8235294117647%;"
+                style="background-position: 72.55% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1507,7 +1507,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 29.41176470588235%;"
+                style="background-position: 49.02% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1518,7 +1518,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 58.8235294117647%;"
+                style="background-position: 60.78% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1529,7 +1529,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 54.90196078431372%;"
+                style="background-position: 60.78% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1540,7 +1540,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 56.86274509803921%;"
+                style="background-position: 60.78% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1551,7 +1551,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 60.78431372549019%;"
+                style="background-position: 60.78% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1562,7 +1562,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 62.745098039215684%;"
+                style="background-position: 60.78% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1573,7 +1573,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 64.70588235294117%;"
+                style="background-position: 60.78% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1584,7 +1584,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 70.58823529411764%;"
+                style="background-position: 60.78% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1595,7 +1595,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 68.62745098039215%;"
+                style="background-position: 60.78% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1606,7 +1606,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 66.66666666666666%;"
+                style="background-position: 60.78% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1617,7 +1617,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 84.31372549019608%;"
+                style="background-position: 62.75% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1628,7 +1628,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 86.27450980392156%;"
+                style="background-position: 62.75% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1639,7 +1639,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 88.23529411764706%;"
+                style="background-position: 62.75% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1650,7 +1650,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 19.6078431372549%;"
+                style="background-position: 43.14% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1661,7 +1661,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31372549019608% 7.8431372549019605%;"
+                style="background-position: 84.31% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1672,7 +1672,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 82.35294117647058%;"
+                style="background-position: 29.41% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1683,7 +1683,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 94.11764705882352%;"
+                style="background-position: 29.41% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1694,7 +1694,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 98.0392156862745%;"
+                style="background-position: 82.35% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1705,7 +1705,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 21.56862745098039%;"
+                style="background-position: 35.29% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1716,7 +1716,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 45.09803921568627%;"
+                style="background-position: 39.22% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1727,7 +1727,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31372549019608% 19.6078431372549%;"
+                style="background-position: 84.31% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1738,7 +1738,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 98.0392156862745%;"
+                style="background-position: 41.18% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1749,7 +1749,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 7.8431372549019605%;"
+                style="background-position: 43.14% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1760,7 +1760,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 84.31372549019608%;"
+                style="background-position: 33.33% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1771,7 +1771,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 1.9607843137254901%;"
+                style="background-position: 39.22% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1782,7 +1782,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 27.45098039215686%;"
+                style="background-position: 31.37% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1793,7 +1793,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 56.86274509803921%;"
+                style="background-position: 35.29% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1804,7 +1804,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 62.745098039215684%;"
+                style="background-position: 31.37% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1815,7 +1815,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 92.15686274509804%;"
+                style="background-position: 35.29% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1826,7 +1826,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 96.07843137254902%;"
+                style="background-position: 33.33% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1837,7 +1837,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 13.72549019607843%;"
+                style="background-position: 39.22% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1848,7 +1848,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 3.9215686274509802%;"
+                style="background-position: 31.37% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1859,7 +1859,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 33.33333333333333%;"
+                style="background-position: 35.29% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1870,7 +1870,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 15.686274509803921%;"
+                style="background-position: 31.37% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1881,7 +1881,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 45.09803921568627%;"
+                style="background-position: 35.29% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1892,7 +1892,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 37.25490196078431%;"
+                style="background-position: 33.33% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1903,7 +1903,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 56.86274509803921%;"
+                style="background-position: 37.25% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1914,7 +1914,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 74.50980392156862%;"
+                style="background-position: 31.37% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1925,7 +1925,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 1.9607843137254901%;"
+                style="background-position: 37.25% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1936,7 +1936,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 25.49019607843137%;"
+                style="background-position: 33.33% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1947,7 +1947,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 45.09803921568627%;"
+                style="background-position: 37.25% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1958,7 +1958,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 49.01960784313725%;"
+                style="background-position: 33.33% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1969,7 +1969,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 68.62745098039215%;"
+                style="background-position: 37.25% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1980,7 +1980,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 13.72549019607843%;"
+                style="background-position: 33.33% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -1991,7 +1991,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 33.33333333333333%;"
+                style="background-position: 37.25% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2002,7 +2002,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 39.2156862745098%;"
+                style="background-position: 31.37% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2013,7 +2013,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 68.62745098039215%;"
+                style="background-position: 35.29% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2024,7 +2024,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 50.98039215686274%;"
+                style="background-position: 31.37% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2035,7 +2035,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 80.3921568627451%;"
+                style="background-position: 35.29% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2046,7 +2046,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 5.88235294117647%;"
+                style="background-position: 35.29% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2057,7 +2057,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 25.49019607843137%;"
+                style="background-position: 39.22% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2068,7 +2068,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 60.78431372549019%;"
+                style="background-position: 33.33% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2079,7 +2079,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 80.3921568627451%;"
+                style="background-position: 37.25% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2090,7 +2090,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 72.54901960784314%;"
+                style="background-position: 33.33% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2101,7 +2101,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 92.15686274509804%;"
+                style="background-position: 37.25% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2112,7 +2112,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 88.23529411764706%;"
+                style="background-position: 39.22% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2123,7 +2123,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 76.47058823529412%;"
+                style="background-position: 39.22% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2134,7 +2134,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 64.70588235294117%;"
+                style="background-position: 39.22% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2145,7 +2145,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 21.56862745098039%;"
+                style="background-position: 56.86% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2156,7 +2156,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 9.80392156862745%;"
+                style="background-position: 56.86% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2167,7 +2167,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 54.90196078431372% 100%;"
+                style="background-position: 54.9% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2178,7 +2178,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 60.78431372549019%;"
+                style="background-position: 45.1% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2189,7 +2189,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 49.01960784313725%;"
+                style="background-position: 45.1% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2200,7 +2200,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 37.25490196078431%;"
+                style="background-position: 45.1% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2211,7 +2211,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 54.90196078431372%;"
+                style="background-position: 43.14% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2222,7 +2222,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 43.13725490196078%;"
+                style="background-position: 43.14% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2233,7 +2233,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 31.372549019607842%;"
+                style="background-position: 43.14% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2244,7 +2244,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 54.90196078431372%;"
+                style="background-position: 76.47% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2255,7 +2255,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 66.66666666666666%;"
+                style="background-position: 43.14% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2266,7 +2266,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 86.27450980392156%;"
+                style="background-position: 41.18% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2277,7 +2277,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 74.50980392156862%;"
+                style="background-position: 41.18% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2288,7 +2288,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 62.745098039215684%;"
+                style="background-position: 41.18% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2299,7 +2299,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 50.98039215686274%;"
+                style="background-position: 41.18% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2310,7 +2310,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31372549019608% 43.13725490196078%;"
+                style="background-position: 84.31% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2321,7 +2321,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31372549019608% 31.372549019607842%;"
+                style="background-position: 84.31% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2332,7 +2332,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 39.2156862745098%;"
+                style="background-position: 41.18% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2343,7 +2343,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 27.45098039215686%;"
+                style="background-position: 41.18% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2354,7 +2354,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 15.686274509803921%;"
+                style="background-position: 41.18% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2365,7 +2365,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 66.66666666666666%;"
+                style="background-position: 76.47% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2376,7 +2376,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 3.9215686274509802%;"
+                style="background-position: 41.18% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2387,7 +2387,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 7.8431372549019605%;"
+                style="background-position: 76.47% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2398,7 +2398,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 19.6078431372549%;"
+                style="background-position: 76.47% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2409,7 +2409,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.13725490196078% 84.31372549019608%;"
+                style="background-position: 43.14% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2420,7 +2420,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 37.25490196078431%;"
+                style="background-position: 15.69% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2431,7 +2431,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 78.4313725490196%;"
+                style="background-position: 76.47% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2442,7 +2442,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27450980392156% 82.35294117647058%;"
+                style="background-position: 86.27% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2453,7 +2453,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27450980392156% 58.8235294117647%;"
+                style="background-position: 86.27% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2464,7 +2464,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27450980392156% 70.58823529411764%;"
+                style="background-position: 86.27% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2475,7 +2475,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.23529411764706% 15.686274509803921%;"
+                style="background-position: 88.24% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2486,7 +2486,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27450980392156% 94.11764705882352%;"
+                style="background-position: 86.27% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2497,7 +2497,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.23529411764706% 3.9215686274509802%;"
+                style="background-position: 88.24% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2508,7 +2508,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.23529411764706% 50.98039215686274%;"
+                style="background-position: 88.24% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2519,7 +2519,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.23529411764706% 27.45098039215686%;"
+                style="background-position: 88.24% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2530,7 +2530,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.23529411764706% 39.2156862745098%;"
+                style="background-position: 88.24% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2541,7 +2541,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.23529411764706% 86.27450980392156%;"
+                style="background-position: 88.24% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2552,7 +2552,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.23529411764706% 62.745098039215684%;"
+                style="background-position: 88.24% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2563,7 +2563,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.23529411764706% 74.50980392156862%;"
+                style="background-position: 88.24% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2574,7 +2574,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 19.6078431372549%;"
+                style="background-position: 90.2% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2585,7 +2585,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.23529411764706% 98.0392156862745%;"
+                style="background-position: 88.24% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2596,7 +2596,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 7.8431372549019605%;"
+                style="background-position: 90.2% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2607,7 +2607,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 35.29411764705882%;"
+                style="background-position: 90.2% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2618,7 +2618,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 31.372549019607842%;"
+                style="background-position: 90.2% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2629,7 +2629,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 33.33333333333333%;"
+                style="background-position: 90.2% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2640,7 +2640,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 41.17647058823529%;"
+                style="background-position: 90.2% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2651,7 +2651,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 37.25490196078431%;"
+                style="background-position: 90.2% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2662,7 +2662,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 39.2156862745098%;"
+                style="background-position: 90.2% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2673,7 +2673,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.70588235294117% 58.8235294117647%;"
+                style="background-position: 64.71% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2684,7 +2684,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.70588235294117% 47.05882352941176%;"
+                style="background-position: 64.71% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2695,7 +2695,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.70588235294117% 35.29411764705882%;"
+                style="background-position: 64.71% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2706,7 +2706,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.70588235294117% 94.11764705882352%;"
+                style="background-position: 64.71% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2717,7 +2717,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.70588235294117% 82.35294117647058%;"
+                style="background-position: 64.71% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2728,7 +2728,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.70588235294117% 70.58823529411764%;"
+                style="background-position: 64.71% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2739,7 +2739,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 1.9607843137254901%;"
+                style="background-position: 62.75% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2750,7 +2750,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 92.15686274509804%;"
+                style="background-position: 60.78% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2761,7 +2761,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78431372549019% 80.3921568627451%;"
+                style="background-position: 60.78% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2772,7 +2772,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 37.25490196078431%;"
+                style="background-position: 62.75% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2783,7 +2783,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 25.49019607843137%;"
+                style="background-position: 62.75% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2794,7 +2794,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 13.72549019607843%;"
+                style="background-position: 62.75% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2805,7 +2805,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 25.49019607843137%;"
+                style="background-position: 45.1% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2816,7 +2816,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 13.72549019607843%;"
+                style="background-position: 45.1% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2827,7 +2827,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 1.9607843137254901%;"
+                style="background-position: 45.1% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2838,7 +2838,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.70588235294117% 11.76470588235294%;"
+                style="background-position: 64.71% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2849,7 +2849,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.70588235294117% 0%;"
+                style="background-position: 64.71% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2860,7 +2860,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 90.19607843137254%;"
+                style="background-position: 62.75% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2871,7 +2871,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 72.54901960784314%;"
+                style="background-position: 62.75% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2882,7 +2882,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 60.78431372549019%;"
+                style="background-position: 62.75% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2893,7 +2893,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.745098039215684% 49.01960784313725%;"
+                style="background-position: 62.75% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2904,7 +2904,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 80.3921568627451%;"
+                style="background-position: 74.51% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2915,7 +2915,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 68.62745098039215%;"
+                style="background-position: 74.51% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2926,7 +2926,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 56.86274509803921%;"
+                style="background-position: 74.51% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2937,7 +2937,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 11.76470588235294%;"
+                style="background-position: 78.43% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2948,7 +2948,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 0%;"
+                style="background-position: 78.43% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2959,7 +2959,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 90.19607843137254%;"
+                style="background-position: 76.47% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2970,7 +2970,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 19.6078431372549%;"
+                style="background-position: 47.06% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2981,7 +2981,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 7.8431372549019605%;"
+                style="background-position: 47.06% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -2992,7 +2992,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 98.0392156862745%;"
+                style="background-position: 45.1% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3003,7 +3003,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 54.90196078431372%;"
+                style="background-position: 47.06% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3014,7 +3014,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 43.13725490196078%;"
+                style="background-position: 47.06% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3025,7 +3025,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 31.372549019607842%;"
+                style="background-position: 47.06% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3036,7 +3036,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.58823529411764% 41.17647058823529%;"
+                style="background-position: 70.59% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3047,7 +3047,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.58823529411764% 29.41176470588235%;"
+                style="background-position: 70.59% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3058,7 +3058,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.58823529411764% 17.64705882352941%;"
+                style="background-position: 70.59% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3069,7 +3069,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.64705882352941% 90.19607843137254%;"
+                style="background-position: 17.65% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3080,7 +3080,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.64705882352941% 78.4313725490196%;"
+                style="background-position: 17.65% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3091,7 +3091,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.64705882352941% 66.66666666666666%;"
+                style="background-position: 17.65% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3102,7 +3102,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 72.54901960784314%;"
+                style="background-position: 45.1% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3113,7 +3113,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 41.17647058823529%;"
+                style="background-position: 56.86% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3124,7 +3124,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 1.9607843137254901%;"
+                style="background-position: 41.18% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3135,7 +3135,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.17647058823529% 0%;"
+                style="background-position: 41.18% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3146,7 +3146,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 100%;"
+                style="background-position: 39.22% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3157,7 +3157,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31372549019608% 78.4313725490196%;"
+                style="background-position: 84.31% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3168,7 +3168,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31372549019608% 54.90196078431372%;"
+                style="background-position: 84.31% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3179,7 +3179,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31372549019608% 66.66666666666666%;"
+                style="background-position: 84.31% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3190,7 +3190,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27450980392156% 11.76470588235294%;"
+                style="background-position: 86.27% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3201,7 +3201,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31372549019608% 90.19607843137254%;"
+                style="background-position: 84.31% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3212,7 +3212,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27450980392156% 0%;"
+                style="background-position: 86.27% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3223,7 +3223,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27450980392156% 47.05882352941176%;"
+                style="background-position: 86.27% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3234,7 +3234,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27450980392156% 23.52941176470588%;"
+                style="background-position: 86.27% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3245,7 +3245,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27450980392156% 35.29411764705882%;"
+                style="background-position: 86.27% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3256,7 +3256,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.58823529411764% 70.58823529411764%;"
+                style="background-position: 70.59% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3267,7 +3267,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.58823529411764% 94.11764705882352%;"
+                style="background-position: 70.59% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3278,7 +3278,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 54.90196078431372% 88.23529411764706%;"
+                style="background-position: 54.9% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3289,7 +3289,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 27.45098039215686%;"
+                style="background-position: 58.82% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3300,7 +3300,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 78.4313725490196%;"
+                style="background-position: 29.41% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3311,7 +3311,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 80.3921568627451%;"
+                style="background-position: 29.41% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3322,7 +3322,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 94.11764705882352%;"
+                style="background-position: 78.43% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3333,7 +3333,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.6078431372549% 39.2156862745098%;"
+                style="background-position: 19.61% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3344,7 +3344,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 94.11764705882352% 86.27450980392156%;"
+                style="background-position: 94.12% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3355,7 +3355,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.64705882352941% 54.90196078431372%;"
+                style="background-position: 17.65% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3366,7 +3366,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.56862745098039% 47.05882352941176%;"
+                style="background-position: 21.57% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3377,7 +3377,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.56862745098039% 35.29411764705882%;"
+                style="background-position: 21.57% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3388,7 +3388,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.56862745098039% 23.52941176470588%;"
+                style="background-position: 21.57% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3399,7 +3399,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.6078431372549% 23.52941176470588%;"
+                style="background-position: 19.61% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3410,7 +3410,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.6078431372549% 11.76470588235294%;"
+                style="background-position: 19.61% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3421,7 +3421,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.6078431372549% 0%;"
+                style="background-position: 19.61% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3432,7 +3432,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.62745098039215% 5.88235294117647%;"
+                style="background-position: 68.63% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3443,7 +3443,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 66.66666666666666% 96.07843137254902%;"
+                style="background-position: 66.67% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3454,7 +3454,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 66.66666666666666% 84.31372549019608%;"
+                style="background-position: 66.67% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3465,7 +3465,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.6078431372549% 78.4313725490196%;"
+                style="background-position: 19.61% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3476,7 +3476,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.6078431372549% 66.66666666666666%;"
+                style="background-position: 19.61% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3487,7 +3487,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.6078431372549% 54.90196078431372%;"
+                style="background-position: 19.61% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3498,7 +3498,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.07843137254902% 11.76470588235294%;"
+                style="background-position: 96.08% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3509,7 +3509,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.07843137254902% 0%;"
+                style="background-position: 96.08% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3520,7 +3520,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 94.11764705882352% 90.19607843137254%;"
+                style="background-position: 94.12% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3531,7 +3531,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.56862745098039% 11.76470588235294%;"
+                style="background-position: 21.57% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3542,7 +3542,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.56862745098039% 0%;"
+                style="background-position: 21.57% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3553,7 +3553,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.6078431372549% 90.19607843137254%;"
+                style="background-position: 19.61% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3564,7 +3564,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.62745098039215% 72.54901960784314%;"
+                style="background-position: 68.63% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3575,7 +3575,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.62745098039215% 60.78431372549019%;"
+                style="background-position: 68.63% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3586,7 +3586,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.62745098039215% 49.01960784313725%;"
+                style="background-position: 68.63% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3597,7 +3597,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.58823529411764% 5.88235294117647%;"
+                style="background-position: 70.59% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3608,7 +3608,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.62745098039215% 96.07843137254902%;"
+                style="background-position: 68.63% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3619,7 +3619,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.62745098039215% 84.31372549019608%;"
+                style="background-position: 68.63% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3630,7 +3630,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.56862745098039% 60.78431372549019%;"
+                style="background-position: 21.57% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3641,7 +3641,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.56862745098039% 58.8235294117647%;"
+                style="background-position: 21.57% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3652,7 +3652,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 47.05882352941176%;"
+                style="background-position: 78.43% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3663,7 +3663,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 35.29411764705882%;"
+                style="background-position: 78.43% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3674,7 +3674,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 23.52941176470588%;"
+                style="background-position: 78.43% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3685,7 +3685,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 100%;"
+                style="background-position: 78.43% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3696,7 +3696,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 98.0392156862745%;"
+                style="background-position: 78.43% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3707,7 +3707,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 96.07843137254902%;"
+                style="background-position: 78.43% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3718,7 +3718,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 23.52941176470588%;"
+                style="background-position: 80.39% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3729,7 +3729,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 11.76470588235294%;"
+                style="background-position: 80.39% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3740,7 +3740,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 0%;"
+                style="background-position: 80.39% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3751,7 +3751,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 58.8235294117647%;"
+                style="background-position: 80.39% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3762,7 +3762,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 47.05882352941176%;"
+                style="background-position: 80.39% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3773,7 +3773,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 35.29411764705882%;"
+                style="background-position: 80.39% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3784,7 +3784,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 82.35294117647058%;"
+                style="background-position: 78.43% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3795,7 +3795,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 70.58823529411764%;"
+                style="background-position: 78.43% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3806,7 +3806,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.4313725490196% 58.8235294117647%;"
+                style="background-position: 78.43% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3817,7 +3817,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 58.8235294117647%;"
+                style="background-position: 39.22% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3828,7 +3828,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 60.78431372549019%;"
+                style="background-position: 39.22% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3839,7 +3839,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 62.745098039215684%;"
+                style="background-position: 39.22% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3850,7 +3850,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 80.3921568627451%;"
+                style="background-position: 47.06% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3861,7 +3861,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 41.17647058823529%;"
+                style="background-position: 39.22% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3872,7 +3872,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 19.6078431372549%;"
+                style="background-position: 35.29% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3883,7 +3883,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 43.13725490196078%;"
+                style="background-position: 39.22% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3894,7 +3894,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 84.31372549019608%;"
+                style="background-position: 47.06% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3905,7 +3905,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 37.25490196078431%;"
+                style="background-position: 39.22% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3916,7 +3916,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29411764705882% 17.64705882352941%;"
+                style="background-position: 35.29% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3927,7 +3927,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 39.2156862745098%;"
+                style="background-position: 39.22% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3938,7 +3938,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.2156862745098% 56.86274509803921%;"
+                style="background-position: 39.22% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3949,7 +3949,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 3.9215686274509802%;"
+                style="background-position: 33.33% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3960,7 +3960,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 7.8431372549019605%;"
+                style="background-position: 33.33% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3971,7 +3971,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 9.80392156862745%;"
+                style="background-position: 33.33% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3982,7 +3982,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 5.88235294117647%;"
+                style="background-position: 33.33% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -3993,7 +3993,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 11.76470588235294%;"
+                style="background-position: 33.33% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4004,7 +4004,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 96.07843137254902%;"
+                style="background-position: 31.37% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4015,7 +4015,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 100%;"
+                style="background-position: 31.37% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4026,7 +4026,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 0%;"
+                style="background-position: 33.33% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4037,7 +4037,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 98.0392156862745%;"
+                style="background-position: 31.37% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4048,7 +4048,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33333333333333% 1.9607843137254901%;"
+                style="background-position: 33.33% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4059,7 +4059,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 23.52941176470588%;"
+                style="background-position: 37.25% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4070,7 +4070,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 27.45098039215686%;"
+                style="background-position: 37.25% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4081,7 +4081,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 29.41176470588235%;"
+                style="background-position: 37.25% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4092,7 +4092,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 25.49019607843137%;"
+                style="background-position: 37.25% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4103,7 +4103,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 31.372549019607842%;"
+                style="background-position: 37.25% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4114,7 +4114,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 88.23529411764706%;"
+                style="background-position: 31.37% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4125,7 +4125,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 86.27450980392156%;"
+                style="background-position: 31.37% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4136,7 +4136,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 94.11764705882352%;"
+                style="background-position: 31.37% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4147,7 +4147,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 90.19607843137254%;"
+                style="background-position: 31.37% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4158,7 +4158,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.372549019607842% 92.15686274509804%;"
+                style="background-position: 31.37% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4169,7 +4169,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 15.686274509803921%;"
+                style="background-position: 37.25% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4180,7 +4180,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 13.72549019607843%;"
+                style="background-position: 37.25% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4191,7 +4191,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 21.56862745098039%;"
+                style="background-position: 37.25% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4202,7 +4202,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 17.64705882352941%;"
+                style="background-position: 37.25% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4213,7 +4213,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25490196078431% 19.6078431372549%;"
+                style="background-position: 37.25% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4224,7 +4224,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 43.13725490196078%;"
+                style="background-position: 76.47% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4235,7 +4235,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 31.372549019607842%;"
+                style="background-position: 49.02% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4246,7 +4246,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 37.25490196078431%;"
+                style="background-position: 27.45% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4257,7 +4257,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 49.01960784313725%;"
+                style="background-position: 27.45% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4268,7 +4268,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.15686274509804% 50.98039215686274%;"
+                style="background-position: 92.16% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4279,7 +4279,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 13.72549019607843%;"
+                style="background-position: 27.45% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4290,7 +4290,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 74.50980392156862%;"
+                style="background-position: 56.86% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4301,7 +4301,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 25.49019607843137%;"
+                style="background-position: 27.45% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4312,7 +4312,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.07843137254902% 58.8235294117647%;"
+                style="background-position: 96.08% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4323,7 +4323,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 21.56862745098039%;"
+                style="background-position: 74.51% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4334,7 +4334,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 86.27450980392156%;"
+                style="background-position: 56.86% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4345,7 +4345,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 62.745098039215684%;"
+                style="background-position: 72.55% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4356,7 +4356,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 74.50980392156862%;"
+                style="background-position: 72.55% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4367,7 +4367,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 62.745098039215684%;"
+                style="background-position: 56.86% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4378,7 +4378,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.07843137254902% 47.05882352941176%;"
+                style="background-position: 96.08% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4389,7 +4389,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 84.31372549019608%;"
+                style="background-position: 27.45% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4400,7 +4400,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 96.07843137254902%;"
+                style="background-position: 27.45% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4411,7 +4411,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 5.88235294117647%;"
+                style="background-position: 29.41% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4422,7 +4422,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.07843137254902% 35.29411764705882%;"
+                style="background-position: 96.08% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4433,7 +4433,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 60.78431372549019%;"
+                style="background-position: 27.45% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4444,7 +4444,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 98.0392156862745%;"
+                style="background-position: 72.55% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4455,7 +4455,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 7.8431372549019605%;"
+                style="background-position: 74.51% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4466,7 +4466,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 86.27450980392156%;"
+                style="background-position: 72.55% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4477,7 +4477,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 72.54901960784314%;"
+                style="background-position: 27.45% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4488,7 +4488,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 33.33333333333333%;"
+                style="background-position: 74.51% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4499,7 +4499,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.07843137254902% 70.58823529411764%;"
+                style="background-position: 96.08% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4510,7 +4510,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 17.64705882352941%;"
+                style="background-position: 29.41% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4521,7 +4521,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 29.41176470588235%;"
+                style="background-position: 29.41% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4532,7 +4532,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.70588235294117% 23.52941176470588%;"
+                style="background-position: 64.71% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4543,7 +4543,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47058823529412% 31.372549019607842%;"
+                style="background-position: 76.47% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4554,7 +4554,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 66.66666666666666% 3.9215686274509802%;"
+                style="background-position: 66.67% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4565,7 +4565,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.50980392156862% 19.6078431372549%;"
+                style="background-position: 74.51% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4576,7 +4576,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 86.27450980392156%;"
+                style="background-position: 45.1% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4587,7 +4587,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 88.23529411764706%;"
+                style="background-position: 25.49% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4598,7 +4598,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 100%;"
+                style="background-position: 25.49% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4609,7 +4609,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 76.47058823529412%;"
+                style="background-position: 29.41% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4620,7 +4620,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 82.35294117647058%;"
+                style="background-position: 25.49% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4631,7 +4631,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 86.27450980392156%;"
+                style="background-position: 25.49% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4642,7 +4642,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 84.31372549019608%;"
+                style="background-position: 25.49% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4653,7 +4653,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 43.13725490196078%;"
+                style="background-position: 90.2% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4664,7 +4664,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 11.76470588235294%;"
+                style="background-position: 27.45% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4675,7 +4675,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45098039215686% 9.80392156862745%;"
+                style="background-position: 27.45% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4686,7 +4686,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 72.54901960784314%;"
+                style="background-position: 47.06% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4697,7 +4697,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 98.0392156862745%;"
+                style="background-position: 47.06% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4708,7 +4708,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 98.0392156862745% 15.686274509803921%;"
+                style="background-position: 98.04% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4719,7 +4719,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 88.23529411764706%;"
+                style="background-position: 47.06% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4730,7 +4730,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 90.19607843137254%;"
+                style="background-position: 47.06% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4741,7 +4741,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 92.15686274509804%;"
+                style="background-position: 47.06% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4752,7 +4752,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 94.11764705882352%;"
+                style="background-position: 47.06% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4763,7 +4763,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 96.07843137254902%;"
+                style="background-position: 47.06% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4774,7 +4774,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 100%;"
+                style="background-position: 47.06% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4785,7 +4785,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 0%;"
+                style="background-position: 49.02% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4796,7 +4796,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 1.9607843137254901%;"
+                style="background-position: 49.02% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4807,7 +4807,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 45.09803921568627%;"
+                style="background-position: 90.2% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4818,7 +4818,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 3.9215686274509802%;"
+                style="background-position: 49.02% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4829,7 +4829,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 98.0392156862745%;"
+                style="background-position: 56.86% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4840,7 +4840,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 5.88235294117647%;"
+                style="background-position: 49.02% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4851,7 +4851,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 7.8431372549019605%;"
+                style="background-position: 49.02% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4862,7 +4862,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 9.80392156862745%;"
+                style="background-position: 49.02% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4873,7 +4873,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 98.0392156862745% 13.72549019607843%;"
+                style="background-position: 98.04% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4884,7 +4884,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 74.50980392156862%;"
+                style="background-position: 47.06% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4895,7 +4895,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 19.6078431372549%;"
+                style="background-position: 49.02% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4906,7 +4906,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 15.686274509803921%;"
+                style="background-position: 49.02% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4917,7 +4917,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 17.64705882352941%;"
+                style="background-position: 49.02% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4928,7 +4928,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 21.56862745098039%;"
+                style="background-position: 49.02% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4939,7 +4939,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 23.52941176470588%;"
+                style="background-position: 49.02% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4950,7 +4950,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 27.45098039215686%;"
+                style="background-position: 49.02% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4961,7 +4961,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 43.13725490196078%;"
+                style="background-position: 49.02% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4972,7 +4972,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 45.09803921568627%;"
+                style="background-position: 49.02% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4983,7 +4983,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 29.41176470588235%;"
+                style="background-position: 58.82% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -4994,7 +4994,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.8235294117647% 31.372549019607842%;"
+                style="background-position: 58.82% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5005,7 +5005,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 47.05882352941176%;"
+                style="background-position: 49.02% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5016,7 +5016,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 54.90196078431372% 86.27450980392156%;"
+                style="background-position: 54.9% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5027,7 +5027,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 45.09803921568627%;"
+                style="background-position: 29.41% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5038,7 +5038,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 33.33333333333333%;"
+                style="background-position: 56.86% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5049,7 +5049,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 47.05882352941176%;"
+                style="background-position: 29.41% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5060,7 +5060,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 49.01960784313725%;"
+                style="background-position: 29.41% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5071,7 +5071,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 50.98039215686274%;"
+                style="background-position: 29.41% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5082,7 +5082,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 49.01960784313725%;"
+                style="background-position: 90.2% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5093,7 +5093,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 50.98039215686274%;"
+                style="background-position: 90.2% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5104,7 +5104,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 52.94117647058823%;"
+                style="background-position: 90.2% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5115,7 +5115,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 54.90196078431372%;"
+                style="background-position: 90.2% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5126,7 +5126,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 52.94117647058823%;"
+                style="background-position: 29.41% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5137,7 +5137,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 54.90196078431372%;"
+                style="background-position: 29.41% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5148,7 +5148,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 56.86274509803921%;"
+                style="background-position: 29.41% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5159,7 +5159,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 58.8235294117647%;"
+                style="background-position: 29.41% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5170,7 +5170,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 60.78431372549019%;"
+                style="background-position: 29.41% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5181,7 +5181,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 62.745098039215684%;"
+                style="background-position: 29.41% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5192,7 +5192,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 64.70588235294117%;"
+                style="background-position: 29.41% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5203,7 +5203,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.54901960784314% 3.9215686274509802%;"
+                style="background-position: 72.55% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5214,7 +5214,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 72.54901960784314%;"
+                style="background-position: 15.69% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5225,7 +5225,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 66.66666666666666%;"
+                style="background-position: 29.41% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5236,7 +5236,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 68.62745098039215%;"
+                style="background-position: 29.41% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5247,7 +5247,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 70.58823529411764%;"
+                style="background-position: 29.41% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5258,7 +5258,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 72.54901960784314%;"
+                style="background-position: 29.41% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5269,7 +5269,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 74.50980392156862%;"
+                style="background-position: 29.41% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5280,7 +5280,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 41.17647058823529%;"
+                style="background-position: 29.41% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5291,7 +5291,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41176470588235% 43.13725490196078%;"
+                style="background-position: 29.41% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5302,7 +5302,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.64705882352941% 5.88235294117647%;"
+                style="background-position: 17.65% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5313,7 +5313,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 74.50980392156862%;"
+                style="background-position: 15.69% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5324,7 +5324,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.19607843137254% 47.05882352941176%;"
+                style="background-position: 90.2% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5335,7 +5335,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 94.11764705882352% 64.70588235294117%;"
+                style="background-position: 94.12% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5346,7 +5346,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 52.94117647058823% 1.9607843137254901%;"
+                style="background-position: 52.94% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5357,7 +5357,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.09803921568627% 84.31372549019608%;"
+                style="background-position: 45.1% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5368,7 +5368,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 76.47058823529412%;"
+                style="background-position: 47.06% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5379,7 +5379,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 78.4313725490196%;"
+                style="background-position: 47.06% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5413,7 +5413,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 60.78431372549019%;"
+                style="background-position: 25.49% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5424,7 +5424,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 94.11764705882352%;"
+                style="background-position: 23.53% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5435,7 +5435,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 72.54901960784314%;"
+                style="background-position: 82.35% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5446,7 +5446,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 62.745098039215684%;"
+                style="background-position: 25.49% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5457,7 +5457,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 100%;"
+                style="background-position: 23.53% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5468,7 +5468,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 37.25490196078431%;"
+                style="background-position: 25.49% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5479,7 +5479,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 70.58823529411764%;"
+                style="background-position: 25.49% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5490,7 +5490,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 66.66666666666666%;"
+                style="background-position: 82.35% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5501,7 +5501,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 52.94117647058823%;"
+                style="background-position: 25.49% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5512,7 +5512,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 74.50980392156862%;"
+                style="background-position: 23.53% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5523,7 +5523,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 49.01960784313725%;"
+                style="background-position: 82.35% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5534,7 +5534,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 49.01960784313725%;"
+                style="background-position: 25.49% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5545,7 +5545,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 68.62745098039215%;"
+                style="background-position: 23.53% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5556,7 +5556,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 70.58823529411764%;"
+                style="background-position: 23.53% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5567,7 +5567,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 58.8235294117647%;"
+                style="background-position: 25.49% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5578,7 +5578,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 86.27450980392156%;"
+                style="background-position: 23.53% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5589,7 +5589,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 54.90196078431372%;"
+                style="background-position: 82.35% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5600,7 +5600,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 84.31372549019608%;"
+                style="background-position: 82.35% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5611,7 +5611,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 70.58823529411764%;"
+                style="background-position: 82.35% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5622,7 +5622,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 47.05882352941176%;"
+                style="background-position: 25.49% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5633,7 +5633,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 62.745098039215684%;"
+                style="background-position: 23.53% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5644,7 +5644,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 64.70588235294117%;"
+                style="background-position: 23.53% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5655,7 +5655,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 66.66666666666666%;"
+                style="background-position: 23.53% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5666,7 +5666,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 64.70588235294117%;"
+                style="background-position: 25.49% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5677,7 +5677,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 0%;"
+                style="background-position: 25.49% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5688,7 +5688,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 1.9607843137254901%;"
+                style="background-position: 25.49% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5699,7 +5699,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 76.47058823529412%;"
+                style="background-position: 25.49% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5710,7 +5710,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 88.23529411764706%;"
+                style="background-position: 23.53% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5721,7 +5721,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 92.15686274509804%;"
+                style="background-position: 23.53% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5732,7 +5732,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 90.19607843137254%;"
+                style="background-position: 23.53% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5743,7 +5743,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 39.2156862745098%;"
+                style="background-position: 25.49% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5754,7 +5754,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 41.17647058823529%;"
+                style="background-position: 25.49% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5765,7 +5765,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 82.35294117647058%;"
+                style="background-position: 82.35% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5776,7 +5776,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 3.9215686274509802%;"
+                style="background-position: 25.49% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5787,7 +5787,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 76.47058823529412%;"
+                style="background-position: 82.35% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5798,7 +5798,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 45.09803921568627%;"
+                style="background-position: 25.49% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5809,7 +5809,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 60.78431372549019%;"
+                style="background-position: 23.53% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5820,7 +5820,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 58.8235294117647%;"
+                style="background-position: 23.53% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5831,7 +5831,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 68.62745098039215%;"
+                style="background-position: 25.49% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5842,7 +5842,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 50.98039215686274%;"
+                style="background-position: 25.49% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5853,7 +5853,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 72.54901960784314%;"
+                style="background-position: 23.53% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5864,7 +5864,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 80.3921568627451%;"
+                style="background-position: 25.49% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5875,7 +5875,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 86.27450980392156%;"
+                style="background-position: 82.35% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5886,7 +5886,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 60.78431372549019%;"
+                style="background-position: 82.35% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5897,7 +5897,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 72.54901960784314%;"
+                style="background-position: 25.49% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5908,7 +5908,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 35.29411764705882%;"
+                style="background-position: 25.49% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5919,7 +5919,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 74.50980392156862%;"
+                style="background-position: 25.49% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5930,7 +5930,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 78.4313725490196%;"
+                style="background-position: 25.49% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5941,7 +5941,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 52.94117647058823%;"
+                style="background-position: 82.35% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5952,7 +5952,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 98.0392156862745%;"
+                style="background-position: 23.53% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5963,7 +5963,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 96.07843137254902%;"
+                style="background-position: 23.53% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5974,7 +5974,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 25.49019607843137%;"
+                style="background-position: 25.49% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5985,7 +5985,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 27.45098039215686%;"
+                style="background-position: 25.49% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -5996,7 +5996,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 29.41176470588235%;"
+                style="background-position: 25.49% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6007,7 +6007,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 31.372549019607842%;"
+                style="background-position: 25.49% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6018,7 +6018,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 33.33333333333333%;"
+                style="background-position: 25.49% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6029,7 +6029,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 54.90196078431372% 25.49019607843137%;"
+                style="background-position: 54.9% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6040,7 +6040,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 56.86274509803921%;"
+                style="background-position: 82.35% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6051,7 +6051,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 58.8235294117647%;"
+                style="background-position: 82.35% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6062,7 +6062,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 64.70588235294117%;"
+                style="background-position: 82.35% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6073,7 +6073,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 66.66666666666666%;"
+                style="background-position: 25.49% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6084,7 +6084,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 78.4313725490196%;"
+                style="background-position: 23.53% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6095,7 +6095,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 23.52941176470588%;"
+                style="background-position: 25.49% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6106,7 +6106,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 74.50980392156862%;"
+                style="background-position: 82.35% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6117,7 +6117,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 84.31372549019608%;"
+                style="background-position: 23.53% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6128,7 +6128,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 54.90196078431372%;"
+                style="background-position: 25.49% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6139,7 +6139,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 76.47058823529412%;"
+                style="background-position: 23.53% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6150,7 +6150,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 88.23529411764706%;"
+                style="background-position: 82.35% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6161,7 +6161,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 90.19607843137254%;"
+                style="background-position: 82.35% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6172,7 +6172,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 56.86274509803921%;"
+                style="background-position: 25.49% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6183,7 +6183,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 80.3921568627451%;"
+                style="background-position: 23.53% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6194,7 +6194,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 43.13725490196078%;"
+                style="background-position: 25.49% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6205,7 +6205,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 17.64705882352941%;"
+                style="background-position: 25.49% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6216,7 +6216,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 19.6078431372549%;"
+                style="background-position: 25.49% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6227,7 +6227,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 21.56862745098039%;"
+                style="background-position: 25.49% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6238,7 +6238,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 62.745098039215684%;"
+                style="background-position: 82.35% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6249,7 +6249,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 5.88235294117647%;"
+                style="background-position: 25.49% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6260,7 +6260,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 7.8431372549019605%;"
+                style="background-position: 25.49% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6271,7 +6271,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 47.05882352941176%;"
+                style="background-position: 82.35% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6282,7 +6282,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 78.4313725490196%;"
+                style="background-position: 82.35% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6293,7 +6293,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 80.3921568627451%;"
+                style="background-position: 82.35% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6304,7 +6304,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 82.35294117647058%;"
+                style="background-position: 23.53% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6315,7 +6315,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 68.62745098039215%;"
+                style="background-position: 82.35% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6326,7 +6326,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 9.80392156862745%;"
+                style="background-position: 25.49% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6337,7 +6337,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 11.76470588235294%;"
+                style="background-position: 25.49% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6348,7 +6348,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 13.72549019607843%;"
+                style="background-position: 25.49% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6359,7 +6359,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49019607843137% 15.686274509803921%;"
+                style="background-position: 25.49% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6370,7 +6370,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 92.15686274509804%;"
+                style="background-position: 82.35% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6381,7 +6381,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 35.29411764705882%;"
+                style="background-position: 56.86% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6392,7 +6392,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86274509803921% 37.25490196078431%;"
+                style="background-position: 56.86% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6403,7 +6403,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 50.98039215686274%;"
+                style="background-position: 82.35% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6414,7 +6414,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.05882352941176% 82.35294117647058%;"
+                style="background-position: 47.06% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6425,7 +6425,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 90.19607843137254%;"
+                style="background-position: 11.76% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6436,7 +6436,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.01960784313725% 49.01960784313725%;"
+                style="background-position: 49.02% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6447,7 +6447,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 39.2156862745098%;"
+                style="background-position: 23.53% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6458,7 +6458,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 92.15686274509804%;"
+                style="background-position: 11.76% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6469,7 +6469,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 70.58823529411764%;"
+                style="background-position: 80.39% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6480,7 +6480,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 94.11764705882352%;"
+                style="background-position: 11.76% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6491,7 +6491,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 96.07843137254902%;"
+                style="background-position: 11.76% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6502,7 +6502,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 98.0392156862745%;"
+                style="background-position: 11.76% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6513,7 +6513,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 88.23529411764706%;"
+                style="background-position: 11.76% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6524,7 +6524,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 76.47058823529412%;"
+                style="background-position: 11.76% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6535,7 +6535,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 78.4313725490196%;"
+                style="background-position: 11.76% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6546,7 +6546,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 80.3921568627451%;"
+                style="background-position: 11.76% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6557,7 +6557,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 82.35294117647058%;"
+                style="background-position: 11.76% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6568,7 +6568,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 84.31372549019608%;"
+                style="background-position: 11.76% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6579,7 +6579,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 0%;"
+                style="background-position: 13.73% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6590,7 +6590,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 1.9607843137254901%;"
+                style="background-position: 13.73% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6601,7 +6601,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.15686274509804% 49.01960784313725%;"
+                style="background-position: 92.16% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6612,7 +6612,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 3.9215686274509802%;"
+                style="background-position: 13.73% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6623,7 +6623,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 5.88235294117647%;"
+                style="background-position: 13.73% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6634,7 +6634,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 7.8431372549019605%;"
+                style="background-position: 13.73% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6645,7 +6645,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 9.80392156862745%;"
+                style="background-position: 13.73% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6679,7 +6679,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 17.64705882352941%;"
+                style="background-position: 13.73% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6690,7 +6690,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 19.6078431372549%;"
+                style="background-position: 13.73% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6701,7 +6701,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 21.56862745098039%;"
+                style="background-position: 13.73% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6712,7 +6712,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 23.52941176470588%;"
+                style="background-position: 13.73% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6723,7 +6723,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 25.49019607843137%;"
+                style="background-position: 13.73% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6734,7 +6734,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 27.45098039215686%;"
+                style="background-position: 13.73% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6745,7 +6745,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 29.41176470588235%;"
+                style="background-position: 13.73% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6756,7 +6756,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 31.372549019607842%;"
+                style="background-position: 13.73% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6767,7 +6767,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 33.33333333333333%;"
+                style="background-position: 13.73% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6778,7 +6778,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 35.29411764705882%;"
+                style="background-position: 13.73% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6789,7 +6789,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 37.25490196078431%;"
+                style="background-position: 13.73% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6800,7 +6800,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 39.2156862745098%;"
+                style="background-position: 13.73% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6811,7 +6811,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 41.17647058823529%;"
+                style="background-position: 13.73% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6822,7 +6822,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 17.64705882352941%;"
+                style="background-position: 82.35% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6833,7 +6833,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 13.72549019607843%;"
+                style="background-position: 13.73% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6844,7 +6844,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 33.33333333333333%;"
+                style="background-position: 82.35% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6855,7 +6855,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 96.07843137254902%;"
+                style="background-position: 80.39% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6866,7 +6866,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 15.686274509803921%;"
+                style="background-position: 13.73% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6877,7 +6877,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 0%;"
+                style="background-position: 82.35% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6888,7 +6888,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 1.9607843137254901%;"
+                style="background-position: 82.35% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6899,7 +6899,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 100%;"
+                style="background-position: 11.76% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6910,7 +6910,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 86.27450980392156%;"
+                style="background-position: 11.76% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6921,7 +6921,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 98.0392156862745%;"
+                style="background-position: 80.39% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6932,7 +6932,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 35.29411764705882%;"
+                style="background-position: 82.35% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6943,7 +6943,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 11.76470588235294%;"
+                style="background-position: 13.73% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6954,7 +6954,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 15.686274509803921%;"
+                style="background-position: 82.35% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6965,7 +6965,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 74.50980392156862%;"
+                style="background-position: 11.76% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6976,7 +6976,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 62.745098039215684%;"
+                style="background-position: 13.73% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6987,7 +6987,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 94.11764705882352%;"
+                style="background-position: 80.39% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -6998,7 +6998,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 3.9215686274509802%;"
+                style="background-position: 82.35% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7009,7 +7009,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 39.2156862745098%;"
+                style="background-position: 82.35% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7020,7 +7020,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 19.6078431372549%;"
+                style="background-position: 82.35% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7031,7 +7031,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 94.11764705882352%;"
+                style="background-position: 82.35% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7042,7 +7042,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 47.05882352941176%;"
+                style="background-position: 13.73% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7053,7 +7053,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 49.01960784313725%;"
+                style="background-position: 13.73% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7064,7 +7064,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 41.17647058823529%;"
+                style="background-position: 82.35% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7075,7 +7075,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 100%;"
+                style="background-position: 80.39% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7086,7 +7086,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 43.13725490196078%;"
+                style="background-position: 13.73% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7097,7 +7097,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 64.70588235294117%;"
+                style="background-position: 13.73% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7108,7 +7108,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 45.09803921568627%;"
+                style="background-position: 13.73% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7119,7 +7119,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 68.62745098039215%;"
+                style="background-position: 11.76% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7130,7 +7130,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 43.13725490196078%;"
+                style="background-position: 82.35% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7141,7 +7141,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 70.58823529411764%;"
+                style="background-position: 11.76% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7152,7 +7152,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76470588235294% 72.54901960784314%;"
+                style="background-position: 11.76% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7163,7 +7163,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 9.80392156862745%;"
+                style="background-position: 82.35% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7174,7 +7174,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 11.76470588235294%;"
+                style="background-position: 82.35% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7185,7 +7185,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 1.9607843137254901%;"
+                style="background-position: 15.69% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7196,7 +7196,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 7.8431372549019605%;"
+                style="background-position: 82.35% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7207,7 +7207,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 0%;"
+                style="background-position: 15.69% 0%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7218,7 +7218,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 29.41176470588235%;"
+                style="background-position: 82.35% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7229,7 +7229,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 5.88235294117647%;"
+                style="background-position: 82.35% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7240,7 +7240,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 25.49019607843137%;"
+                style="background-position: 15.69% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7251,7 +7251,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 45.09803921568627%;"
+                style="background-position: 82.35% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7262,7 +7262,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 100%;"
+                style="background-position: 13.73% 100%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7273,7 +7273,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 50.98039215686274%;"
+                style="background-position: 13.73% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7284,7 +7284,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 52.94117647058823%;"
+                style="background-position: 13.73% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7295,7 +7295,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 54.90196078431372%;"
+                style="background-position: 13.73% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7306,7 +7306,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 56.86274509803921%;"
+                style="background-position: 13.73% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7317,7 +7317,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 58.8235294117647%;"
+                style="background-position: 13.73% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7328,7 +7328,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 60.78431372549019%;"
+                style="background-position: 13.73% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7339,7 +7339,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 66.66666666666666%;"
+                style="background-position: 13.73% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7350,7 +7350,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 70.58823529411764%;"
+                style="background-position: 13.73% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7361,7 +7361,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 72.54901960784314%;"
+                style="background-position: 13.73% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7372,7 +7372,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 74.50980392156862%;"
+                style="background-position: 13.73% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7383,7 +7383,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 76.47058823529412%;"
+                style="background-position: 13.73% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7394,7 +7394,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 68.62745098039215%;"
+                style="background-position: 13.73% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7405,7 +7405,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 21.56862745098039%;"
+                style="background-position: 82.35% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7416,7 +7416,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 23.52941176470588%;"
+                style="background-position: 82.35% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7427,7 +7427,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 25.49019607843137%;"
+                style="background-position: 82.35% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7438,7 +7438,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 78.4313725490196%;"
+                style="background-position: 13.73% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7449,7 +7449,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 80.3921568627451%;"
+                style="background-position: 13.73% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7460,7 +7460,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 82.35294117647058%;"
+                style="background-position: 13.73% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7471,7 +7471,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 84.31372549019608%;"
+                style="background-position: 13.73% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7482,7 +7482,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 86.27450980392156%;"
+                style="background-position: 13.73% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7493,7 +7493,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 31.372549019607842%;"
+                style="background-position: 15.69% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7504,7 +7504,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 98.0392156862745%;"
+                style="background-position: 13.73% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7515,7 +7515,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 37.25490196078431%;"
+                style="background-position: 82.35% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7526,7 +7526,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 88.23529411764706%;"
+                style="background-position: 13.73% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7537,7 +7537,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 90.19607843137254%;"
+                style="background-position: 13.73% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7548,7 +7548,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 92.15686274509804%;"
+                style="background-position: 13.73% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7559,7 +7559,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 94.11764705882352%;"
+                style="background-position: 13.73% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7570,7 +7570,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.72549019607843% 96.07843137254902%;"
+                style="background-position: 13.73% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7581,7 +7581,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 19.6078431372549%;"
+                style="background-position: 15.69% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7592,7 +7592,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 13.72549019607843%;"
+                style="background-position: 82.35% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7603,7 +7603,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.15686274509804% 47.05882352941176%;"
+                style="background-position: 92.16% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7614,7 +7614,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 5.88235294117647%;"
+                style="background-position: 15.69% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7625,7 +7625,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 7.8431372549019605%;"
+                style="background-position: 15.69% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7636,7 +7636,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 23.52941176470588%;"
+                style="background-position: 15.69% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7647,7 +7647,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 9.80392156862745%;"
+                style="background-position: 15.69% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7658,7 +7658,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 11.76470588235294%;"
+                style="background-position: 15.69% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7669,7 +7669,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 13.72549019607843%;"
+                style="background-position: 15.69% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7680,7 +7680,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 15.686274509803921%;"
+                style="background-position: 15.69% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7691,7 +7691,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 17.64705882352941%;"
+                style="background-position: 15.69% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7702,7 +7702,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 74.50980392156862%;"
+                style="background-position: 80.39% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7713,7 +7713,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 76.47058823529412%;"
+                style="background-position: 80.39% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7724,7 +7724,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 31.372549019607842%;"
+                style="background-position: 82.35% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7735,7 +7735,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35294117647058% 27.45098039215686%;"
+                style="background-position: 82.35% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7746,7 +7746,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 21.56862745098039%;"
+                style="background-position: 15.69% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7757,7 +7757,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.686274509803921% 3.9215686274509802%;"
+                style="background-position: 15.69% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7768,7 +7768,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.3921568627451% 78.4313725490196%;"
+                style="background-position: 80.39% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7779,7 +7779,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 52.94117647058823% 86.27450980392156%;"
+                style="background-position: 52.94% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7790,7 +7790,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.52941176470588% 47.05882352941176%;"
+                style="background-position: 23.53% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
               >
                 
               </span>
@@ -7832,7 +7832,7 @@ exports[`Picker renders correctly 1`] = `
         >
           <span
             class="emoji-set-apple emoji-type-image"
-            style="background-position: 23.52941176470588% 17.64705882352941%;"
+            style="background-position: 23.53% 17.65%;"
           >
             
           </span>

--- a/spec/__snapshots__/picker-spec.js.snap
+++ b/spec/__snapshots__/picker-spec.js.snap
@@ -274,7 +274,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -285,7 +285,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -296,7 +296,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -307,7 +307,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -318,7 +318,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -329,7 +329,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -340,7 +340,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -351,7 +351,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -362,7 +362,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -373,7 +373,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -384,7 +384,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -395,7 +395,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -406,7 +406,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -417,7 +417,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -428,7 +428,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 98.04% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 98.04% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -439,7 +439,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -473,7 +473,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -484,7 +484,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -495,7 +495,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -506,7 +506,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -517,7 +517,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 52.94%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -528,7 +528,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -539,7 +539,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -550,7 +550,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -561,7 +561,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 64.71%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -572,7 +572,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -583,7 +583,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -594,7 +594,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -605,7 +605,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -616,7 +616,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -627,7 +627,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -638,7 +638,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -649,7 +649,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -660,7 +660,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.16% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 92.16% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -671,7 +671,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -682,7 +682,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -693,7 +693,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -704,7 +704,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -715,7 +715,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -726,7 +726,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -737,7 +737,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -748,7 +748,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -759,7 +759,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -770,7 +770,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -781,7 +781,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -792,7 +792,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -803,7 +803,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -814,7 +814,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -825,7 +825,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -836,7 +836,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -847,7 +847,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -858,7 +858,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -869,7 +869,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -880,7 +880,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -891,7 +891,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -902,7 +902,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -913,7 +913,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 52.94%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -924,7 +924,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -935,7 +935,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -946,7 +946,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -957,7 +957,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -968,7 +968,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -979,7 +979,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -990,7 +990,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1001,7 +1001,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.16% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 92.16% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1012,7 +1012,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1023,7 +1023,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1034,7 +1034,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1045,7 +1045,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1056,7 +1056,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1067,7 +1067,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1078,7 +1078,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1089,7 +1089,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1100,7 +1100,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1111,7 +1111,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1122,7 +1122,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1133,7 +1133,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1144,7 +1144,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1155,7 +1155,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1166,7 +1166,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1177,7 +1177,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1188,7 +1188,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1199,7 +1199,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1210,7 +1210,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 9.8%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1221,7 +1221,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1232,7 +1232,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1243,7 +1243,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 52.94%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1254,7 +1254,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1265,7 +1265,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1276,7 +1276,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1287,7 +1287,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1298,7 +1298,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1309,7 +1309,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1320,7 +1320,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1331,7 +1331,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1342,7 +1342,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1353,7 +1353,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1364,7 +1364,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1375,7 +1375,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1386,7 +1386,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 52.94%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1397,7 +1397,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1408,7 +1408,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1419,7 +1419,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1430,7 +1430,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1441,7 +1441,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1452,7 +1452,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.16% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 92.16% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1463,7 +1463,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1474,7 +1474,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1485,7 +1485,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1496,7 +1496,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1507,7 +1507,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1518,7 +1518,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1529,7 +1529,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1540,7 +1540,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1551,7 +1551,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1562,7 +1562,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1573,7 +1573,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 64.71%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1584,7 +1584,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1595,7 +1595,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1606,7 +1606,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1617,7 +1617,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1628,7 +1628,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1639,7 +1639,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1650,7 +1650,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1661,7 +1661,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 84.31% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1672,7 +1672,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1683,7 +1683,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1694,7 +1694,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1705,7 +1705,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1716,7 +1716,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1727,7 +1727,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 84.31% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1738,7 +1738,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1749,7 +1749,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1760,7 +1760,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1771,7 +1771,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1782,7 +1782,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1793,7 +1793,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1804,7 +1804,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1815,7 +1815,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1826,7 +1826,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1837,7 +1837,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1848,7 +1848,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1859,7 +1859,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1870,7 +1870,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1881,7 +1881,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1892,7 +1892,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1903,7 +1903,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1914,7 +1914,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1925,7 +1925,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1936,7 +1936,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1947,7 +1947,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1958,7 +1958,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1969,7 +1969,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1980,7 +1980,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -1991,7 +1991,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2002,7 +2002,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2013,7 +2013,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2024,7 +2024,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2035,7 +2035,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2046,7 +2046,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2057,7 +2057,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2068,7 +2068,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2079,7 +2079,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2090,7 +2090,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2101,7 +2101,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2112,7 +2112,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2123,7 +2123,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2134,7 +2134,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 64.71%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2145,7 +2145,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2156,7 +2156,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 9.8%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2167,7 +2167,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 54.9% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 54.9% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2178,7 +2178,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2189,7 +2189,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2200,7 +2200,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2211,7 +2211,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2222,7 +2222,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2233,7 +2233,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2244,7 +2244,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2255,7 +2255,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2266,7 +2266,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2277,7 +2277,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2288,7 +2288,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2299,7 +2299,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2310,7 +2310,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 84.31% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2321,7 +2321,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 84.31% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2332,7 +2332,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2343,7 +2343,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2354,7 +2354,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2365,7 +2365,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2376,7 +2376,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2387,7 +2387,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2398,7 +2398,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2409,7 +2409,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 43.14% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 43.14% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2420,7 +2420,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2431,7 +2431,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2442,7 +2442,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 86.27% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2453,7 +2453,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 86.27% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2464,7 +2464,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 86.27% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2475,7 +2475,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.24% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 88.24% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2486,7 +2486,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 86.27% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2497,7 +2497,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.24% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 88.24% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2508,7 +2508,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.24% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 88.24% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2519,7 +2519,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.24% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 88.24% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2530,7 +2530,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.24% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 88.24% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2541,7 +2541,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.24% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 88.24% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2552,7 +2552,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.24% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 88.24% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2563,7 +2563,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.24% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 88.24% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2574,7 +2574,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2585,7 +2585,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 88.24% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 88.24% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2596,7 +2596,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2607,7 +2607,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2618,7 +2618,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2629,7 +2629,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2640,7 +2640,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2651,7 +2651,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2662,7 +2662,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2673,7 +2673,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.71% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 64.71% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2684,7 +2684,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.71% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 64.71% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2695,7 +2695,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.71% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 64.71% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2706,7 +2706,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.71% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 64.71% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2717,7 +2717,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.71% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 64.71% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2728,7 +2728,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.71% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 64.71% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2739,7 +2739,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2750,7 +2750,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2761,7 +2761,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 60.78% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 60.78% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2772,7 +2772,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2783,7 +2783,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2794,7 +2794,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2805,7 +2805,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2816,7 +2816,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2827,7 +2827,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2838,7 +2838,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.71% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 64.71% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2849,7 +2849,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.71% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 64.71% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2860,7 +2860,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2871,7 +2871,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2882,7 +2882,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2893,7 +2893,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 62.75% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 62.75% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2904,7 +2904,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2915,7 +2915,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2926,7 +2926,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2937,7 +2937,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2948,7 +2948,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2959,7 +2959,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2970,7 +2970,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2981,7 +2981,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -2992,7 +2992,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3003,7 +3003,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3014,7 +3014,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3025,7 +3025,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3036,7 +3036,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.59% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 70.59% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3047,7 +3047,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.59% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 70.59% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3058,7 +3058,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.59% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 70.59% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3069,7 +3069,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.65% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 17.65% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3080,7 +3080,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.65% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 17.65% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3091,7 +3091,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.65% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 17.65% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3102,7 +3102,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3113,7 +3113,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3124,7 +3124,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3135,7 +3135,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 41.18% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 41.18% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3146,7 +3146,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3157,7 +3157,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 84.31% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3168,7 +3168,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 84.31% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3179,7 +3179,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 84.31% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3190,7 +3190,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 86.27% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3201,7 +3201,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 84.31% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 84.31% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3212,7 +3212,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 86.27% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3223,7 +3223,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 86.27% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3234,7 +3234,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 86.27% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3245,7 +3245,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 86.27% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 86.27% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3256,7 +3256,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.59% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 70.59% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3267,7 +3267,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.59% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 70.59% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3278,7 +3278,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 54.9% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 54.9% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3289,7 +3289,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3300,7 +3300,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3311,7 +3311,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3322,7 +3322,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3333,7 +3333,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.61% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 19.61% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3344,7 +3344,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 94.12% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 94.12% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3355,7 +3355,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.65% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 17.65% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3366,7 +3366,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.57% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 21.57% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3377,7 +3377,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.57% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 21.57% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3388,7 +3388,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.57% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 21.57% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3399,7 +3399,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.61% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 19.61% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3410,7 +3410,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.61% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 19.61% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3421,7 +3421,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.61% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 19.61% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3432,7 +3432,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.63% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 68.63% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3443,7 +3443,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 66.67% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 66.67% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3454,7 +3454,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 66.67% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 66.67% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3465,7 +3465,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.61% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 19.61% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3476,7 +3476,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.61% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 19.61% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3487,7 +3487,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.61% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 19.61% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3498,7 +3498,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.08% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 96.08% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3509,7 +3509,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.08% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 96.08% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3520,7 +3520,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 94.12% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 94.12% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3531,7 +3531,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.57% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 21.57% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3542,7 +3542,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.57% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 21.57% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3553,7 +3553,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 19.61% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 19.61% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3564,7 +3564,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.63% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 68.63% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3575,7 +3575,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.63% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 68.63% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3586,7 +3586,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.63% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 68.63% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3597,7 +3597,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 70.59% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 70.59% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3608,7 +3608,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.63% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 68.63% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3619,7 +3619,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 68.63% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 68.63% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3630,7 +3630,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.57% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 21.57% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3641,7 +3641,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 21.57% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 21.57% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3652,7 +3652,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3663,7 +3663,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3674,7 +3674,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3685,7 +3685,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3696,7 +3696,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3707,7 +3707,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3718,7 +3718,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3729,7 +3729,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3740,7 +3740,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3751,7 +3751,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3762,7 +3762,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3773,7 +3773,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3784,7 +3784,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3795,7 +3795,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3806,7 +3806,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 78.43% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 78.43% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3817,7 +3817,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3828,7 +3828,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3839,7 +3839,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3850,7 +3850,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3861,7 +3861,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3872,7 +3872,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3883,7 +3883,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3894,7 +3894,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3905,7 +3905,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3916,7 +3916,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 35.29% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 35.29% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3927,7 +3927,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3938,7 +3938,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 39.22% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 39.22% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3949,7 +3949,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3960,7 +3960,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3971,7 +3971,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 9.8%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3982,7 +3982,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -3993,7 +3993,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4004,7 +4004,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4015,7 +4015,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4026,7 +4026,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4037,7 +4037,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4048,7 +4048,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 33.33% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 33.33% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4059,7 +4059,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4070,7 +4070,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4081,7 +4081,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4092,7 +4092,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4103,7 +4103,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4114,7 +4114,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4125,7 +4125,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4136,7 +4136,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4147,7 +4147,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4158,7 +4158,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 31.37% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 31.37% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4169,7 +4169,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4180,7 +4180,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4191,7 +4191,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4202,7 +4202,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4213,7 +4213,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 37.25% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 37.25% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4224,7 +4224,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4235,7 +4235,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4246,7 +4246,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4257,7 +4257,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4268,7 +4268,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.16% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 92.16% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4279,7 +4279,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4290,7 +4290,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4301,7 +4301,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4312,7 +4312,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.08% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 96.08% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4323,7 +4323,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4334,7 +4334,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4345,7 +4345,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4356,7 +4356,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4367,7 +4367,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4378,7 +4378,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.08% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 96.08% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4389,7 +4389,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4400,7 +4400,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4411,7 +4411,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4422,7 +4422,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.08% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 96.08% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4433,7 +4433,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4444,7 +4444,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4455,7 +4455,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4466,7 +4466,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4477,7 +4477,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4488,7 +4488,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4499,7 +4499,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 96.08% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 96.08% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4510,7 +4510,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4521,7 +4521,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4532,7 +4532,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 64.71% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 64.71% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4543,7 +4543,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 76.47% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 76.47% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4554,7 +4554,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 66.67% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 66.67% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4565,7 +4565,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 74.51% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 74.51% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4576,7 +4576,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4587,7 +4587,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4598,7 +4598,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4609,7 +4609,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4620,7 +4620,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4631,7 +4631,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4642,7 +4642,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4653,7 +4653,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4664,7 +4664,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4675,7 +4675,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 27.45% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 27.45% 9.8%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4686,7 +4686,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4697,7 +4697,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4708,7 +4708,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 98.04% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 98.04% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4719,7 +4719,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4730,7 +4730,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4741,7 +4741,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4752,7 +4752,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4763,7 +4763,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4774,7 +4774,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4785,7 +4785,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4796,7 +4796,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4807,7 +4807,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4818,7 +4818,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4829,7 +4829,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4840,7 +4840,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4851,7 +4851,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4862,7 +4862,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 9.8%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4873,7 +4873,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 98.04% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 98.04% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4884,7 +4884,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4895,7 +4895,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4906,7 +4906,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4917,7 +4917,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4928,7 +4928,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4939,7 +4939,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4950,7 +4950,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4961,7 +4961,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4972,7 +4972,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4983,7 +4983,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -4994,7 +4994,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 58.82% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 58.82% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5005,7 +5005,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5016,7 +5016,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 54.9% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 54.9% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5027,7 +5027,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5038,7 +5038,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5049,7 +5049,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5060,7 +5060,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5071,7 +5071,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5082,7 +5082,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5093,7 +5093,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5104,7 +5104,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 52.94%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5115,7 +5115,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5126,7 +5126,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 52.94%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5137,7 +5137,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5148,7 +5148,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5159,7 +5159,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5170,7 +5170,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5181,7 +5181,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5192,7 +5192,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 64.71%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5203,7 +5203,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 72.55% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 72.55% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5214,7 +5214,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5225,7 +5225,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5236,7 +5236,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5247,7 +5247,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5258,7 +5258,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5269,7 +5269,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5280,7 +5280,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5291,7 +5291,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 29.41% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 29.41% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5302,7 +5302,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 17.65% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 17.65% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5313,7 +5313,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5324,7 +5324,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 90.2% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 90.2% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5335,7 +5335,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 94.12% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 94.12% 64.71%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5346,7 +5346,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 52.94% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 52.94% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5357,7 +5357,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 45.1% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 45.1% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5368,7 +5368,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5379,7 +5379,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5413,7 +5413,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5424,7 +5424,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5435,7 +5435,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5446,7 +5446,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5457,7 +5457,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5468,7 +5468,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5479,7 +5479,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5490,7 +5490,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5501,7 +5501,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 52.94%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5512,7 +5512,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5523,7 +5523,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5534,7 +5534,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5545,7 +5545,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5556,7 +5556,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5567,7 +5567,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5578,7 +5578,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5589,7 +5589,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5600,7 +5600,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5611,7 +5611,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5622,7 +5622,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5633,7 +5633,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5644,7 +5644,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 64.71%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5655,7 +5655,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5666,7 +5666,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 64.71%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5677,7 +5677,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5688,7 +5688,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5699,7 +5699,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5710,7 +5710,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5721,7 +5721,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5732,7 +5732,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5743,7 +5743,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5754,7 +5754,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5765,7 +5765,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5776,7 +5776,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5787,7 +5787,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5798,7 +5798,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5809,7 +5809,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5820,7 +5820,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5831,7 +5831,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5842,7 +5842,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5853,7 +5853,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5864,7 +5864,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5875,7 +5875,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5886,7 +5886,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5897,7 +5897,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5908,7 +5908,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5919,7 +5919,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5930,7 +5930,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5941,7 +5941,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 52.94%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5952,7 +5952,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5963,7 +5963,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5974,7 +5974,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5985,7 +5985,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -5996,7 +5996,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6007,7 +6007,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6018,7 +6018,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6029,7 +6029,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 54.9% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 54.9% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6040,7 +6040,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6051,7 +6051,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6062,7 +6062,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 64.71%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6073,7 +6073,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6084,7 +6084,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6095,7 +6095,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6106,7 +6106,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6117,7 +6117,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6128,7 +6128,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6139,7 +6139,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6150,7 +6150,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6161,7 +6161,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6172,7 +6172,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6183,7 +6183,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6194,7 +6194,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6205,7 +6205,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6216,7 +6216,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6227,7 +6227,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6238,7 +6238,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6249,7 +6249,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6260,7 +6260,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6271,7 +6271,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6282,7 +6282,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6293,7 +6293,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6304,7 +6304,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6315,7 +6315,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6326,7 +6326,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 9.8%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6337,7 +6337,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6348,7 +6348,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6359,7 +6359,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 25.49% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 25.49% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6370,7 +6370,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6381,7 +6381,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6392,7 +6392,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 56.86% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 56.86% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6403,7 +6403,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6414,7 +6414,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 47.06% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 47.06% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6425,7 +6425,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6436,7 +6436,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 49.02% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 49.02% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6447,7 +6447,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6458,7 +6458,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6469,7 +6469,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6480,7 +6480,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6491,7 +6491,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6502,7 +6502,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6513,7 +6513,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6524,7 +6524,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6535,7 +6535,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6546,7 +6546,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6557,7 +6557,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6568,7 +6568,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6579,7 +6579,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6590,7 +6590,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6601,7 +6601,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.16% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 92.16% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6612,7 +6612,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6623,7 +6623,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6634,7 +6634,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6645,7 +6645,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 9.8%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6679,7 +6679,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6690,7 +6690,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6701,7 +6701,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6712,7 +6712,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6723,7 +6723,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6734,7 +6734,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6745,7 +6745,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6756,7 +6756,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6767,7 +6767,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6778,7 +6778,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6789,7 +6789,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6800,7 +6800,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6811,7 +6811,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6822,7 +6822,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6833,7 +6833,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6844,7 +6844,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 33.33%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 33.33%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6855,7 +6855,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6866,7 +6866,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6877,7 +6877,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6888,7 +6888,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6899,7 +6899,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6910,7 +6910,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6921,7 +6921,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6932,7 +6932,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 35.29%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 35.29%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6943,7 +6943,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6954,7 +6954,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6965,7 +6965,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6976,7 +6976,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 62.75%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 62.75%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6987,7 +6987,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -6998,7 +6998,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7009,7 +7009,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 39.22%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 39.22%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7020,7 +7020,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7031,7 +7031,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7042,7 +7042,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7053,7 +7053,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 49.02%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 49.02%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7064,7 +7064,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 41.18%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 41.18%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7075,7 +7075,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7086,7 +7086,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7097,7 +7097,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 64.71%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 64.71%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7108,7 +7108,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7119,7 +7119,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7130,7 +7130,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 43.14%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 43.14%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7141,7 +7141,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7152,7 +7152,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 11.76% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 11.76% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7163,7 +7163,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 9.8%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7174,7 +7174,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7185,7 +7185,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 1.96%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 1.96%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7196,7 +7196,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7207,7 +7207,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 0%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 0%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7218,7 +7218,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 29.41%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 29.41%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7229,7 +7229,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7240,7 +7240,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7251,7 +7251,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 45.1%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 45.1%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7262,7 +7262,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 100%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 100%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7273,7 +7273,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 50.98%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 50.98%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7284,7 +7284,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 52.94%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 52.94%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7295,7 +7295,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 54.9%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 54.9%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7306,7 +7306,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 56.86%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 56.86%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7317,7 +7317,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 58.82%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 58.82%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7328,7 +7328,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 60.78%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 60.78%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7339,7 +7339,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 66.67%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 66.67%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7350,7 +7350,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 70.59%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 70.59%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7361,7 +7361,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 72.55%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 72.55%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7372,7 +7372,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7383,7 +7383,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7394,7 +7394,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 68.63%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 68.63%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7405,7 +7405,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7416,7 +7416,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7427,7 +7427,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 25.49%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 25.49%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7438,7 +7438,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7449,7 +7449,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 80.39%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 80.39%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7460,7 +7460,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 82.35%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 82.35%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7471,7 +7471,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 84.31%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 84.31%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7482,7 +7482,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7493,7 +7493,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7504,7 +7504,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 98.04%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 98.04%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7515,7 +7515,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 37.25%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 37.25%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7526,7 +7526,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 88.24%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 88.24%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7537,7 +7537,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 90.2%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 90.2%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7548,7 +7548,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 92.16%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 92.16%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7559,7 +7559,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 94.12%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 94.12%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7570,7 +7570,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 13.73% 96.08%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 13.73% 96.08%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7581,7 +7581,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 19.61%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 19.61%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7592,7 +7592,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7603,7 +7603,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 92.16% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 92.16% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7614,7 +7614,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 5.88%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 5.88%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7625,7 +7625,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 7.84%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 7.84%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7636,7 +7636,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 23.53%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 23.53%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7647,7 +7647,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 9.8%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 9.8%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7658,7 +7658,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 11.76%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 11.76%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7669,7 +7669,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 13.73%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 13.73%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7680,7 +7680,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 15.69%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 15.69%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7691,7 +7691,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 17.65%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 17.65%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7702,7 +7702,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 74.51%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 74.51%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7713,7 +7713,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 76.47%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 76.47%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7724,7 +7724,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 31.37%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 31.37%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7735,7 +7735,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 82.35% 27.45%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 82.35% 27.45%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7746,7 +7746,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 21.57%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 21.57%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7757,7 +7757,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 15.69% 3.92%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 15.69% 3.92%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7768,7 +7768,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 80.39% 78.43%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 80.39% 78.43%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7779,7 +7779,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 52.94% 86.27%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 52.94% 86.27%; width: 24px; height: 24px;"
               >
                 
               </span>
@@ -7790,7 +7790,7 @@ exports[`Picker renders correctly 1`] = `
             >
               <span
                 class="emoji-set-apple emoji-type-image"
-                style="background-position: 23.53% 47.06%; width: 24px; height: 24px; font-size: 19.2px;"
+                style="background-position: 23.53% 47.06%; width: 24px; height: 24px;"
               >
                 
               </span>

--- a/spec/picker-spec.js
+++ b/spec/picker-spec.js
@@ -207,6 +207,52 @@ describe('emjoi preview', () => {
   })
 })
 
+describe('emjoiSize', () => {
+  const picker = mount(Picker)
+
+  it('default emojiSize is 24', () => {
+    let emoji = picker.find('[data-title="+1"]')
+    // The inner span with applied inline style.
+    let emojiSpan = emoji.element.childNodes[0]
+    expect(emojiSpan.style['width']).toBe('24px')
+    expect(emojiSpan.style.cssText).toBe(
+      'background-position: 27.45% 96.08%; width: 24px; height: 24px;',
+    )
+  })
+
+  it('emojiSize can be changed', () => {
+    picker.setProps({ emojiSize: 20 })
+    let emoji = picker.find('[data-title="+1"]')
+    // The inner span with applied inline style.
+    let emojiSpan = emoji.element.childNodes[0]
+    expect(emojiSpan.style.cssText).toBe(
+      'background-position: 27.45% 96.08%; width: 20px; height: 20px;',
+    )
+  })
+
+  it('native emoji font size is 19.2px by default', () => {
+    picker.setProps({ emojiSize: 24, native: true })
+    let emoji = picker.find('[data-title="+1"]')
+    // The inner span with applied inline style.
+    let emojiSpan = emoji.element.childNodes[0]
+    // Font-size is 80% of width/height value.
+    expect(emojiSpan.style.cssText).toBe(
+      'background-position: 27.45% 96.08%; font-size: 19.2px;',
+    )
+  })
+
+  it('native emoji font size is smaller when emojiSize is smaller', () => {
+    picker.setProps({ emojiSize: 20, native: true })
+    let emoji = picker.find('[data-title="+1"]')
+    // The inner span with applied inline style.
+    let emojiSpan = emoji.element.childNodes[0]
+    // Font-size is 80% of width/height value.
+    expect(emojiSpan.style.cssText).toBe(
+      'background-position: 27.45% 96.08%; font-size: 16px;',
+    )
+  })
+})
+
 describe('search', () => {
   let index = new EmojiIndex(data)
   const picker = mount(NimblePicker, {

--- a/src/components/category.vue
+++ b/src/components/category.vue
@@ -78,12 +78,13 @@ export default {
       return this.emojis.map((emoji) => {
           let emojiObject = emoji
           let emojiView = new EmojiView(
-            emoji, 
+            emoji,
             this.emojiProps.skin,
             this.emojiProps.set,
             this.emojiProps.native,
             this.emojiProps.fallback,
-            this.emojiProps.emojiTooltip
+            this.emojiProps.emojiTooltip,
+            this.emojiProps.emojiSize,
           )
           return { emojiObject, emojiView }
       })

--- a/src/components/picker/nimblePicker.vue
+++ b/src/components/picker/nimblePicker.vue
@@ -157,6 +157,7 @@ export default {
         skin: this.activeSkin,
         set: this.set,
         emojiTooltip: this.emojiTooltip,
+        emojiSize: this.emojiSize,
         onEnter: this.onEmojiEnter.bind(this),
         onLeave: this.onEmojiLeave.bind(this),
         onClick: this.onEmojiClick.bind(this)

--- a/src/utils/emoji-data.js
+++ b/src/utils/emoji-data.js
@@ -470,8 +470,8 @@ export class Emoji {
 
   getPosition() {
     let multiply = 100 / (SHEET_COLUMNS - 1),
-      x = multiply * this._data.sheet_x,
-      y = multiply * this._data.sheet_y
+      x = Math.round(multiply * this._data.sheet_x * 100) / 100,
+      y = Math.round(multiply * this._data.sheet_y * 100) / 100
     return `${x}% ${y}%`
   }
 }
@@ -535,7 +535,7 @@ export class EmojiView {
         // font-size is used for native emoji which we need
         // to scale with 0.8 factor to have them look approximately
         // the same size as image-based emojl.
-        fontSize: emojiSize * 0.8 + 'px',
+        fontSize: Math.round(emojiSize * 0.8 * 10) / 10 + 'px',
       })
     }
     return cssStyle

--- a/src/utils/emoji-data.js
+++ b/src/utils/emoji-data.js
@@ -483,8 +483,9 @@ export class EmojiView {
    * native - boolean, whether to render native emoji
    * fallback - fallback function to render missing emoji, optional
    * emojiTooltip - wether we need to show the emoji tooltip, optional
+   * emojiSize - emoji size in pixels, optional
    */
-  constructor(emoji, skin, set, native, fallback, emojiTooltip) {
+  constructor(emoji, skin, set, native, fallback, emojiTooltip, emojiSize) {
     this._emoji = emoji
     this._native = native
     this._skin = skin
@@ -493,7 +494,7 @@ export class EmojiView {
 
     this.canRender = this._canRender()
     this.cssClass = this._cssClass()
-    this.cssStyle = this._cssStyle()
+    this.cssStyle = this._cssStyle(emojiSize)
     this.content = this._content()
     this.title = emojiTooltip === true ? emoji.short_name : null
 
@@ -514,19 +515,27 @@ export class EmojiView {
     return ['emoji-set-' + this._set, 'emoji-type-' + this._emojiType()]
   }
 
-  _cssStyle() {
+  _cssStyle(emojiSize) {
+    let cssStyle = {}
     if (this._isCustom()) {
-      return {
+      cssStyle = {
         backgroundImage: 'url(' + this.getEmoji()._data.imageUrl + ')',
         backgroundSize: '100%',
       }
     }
     if (this._hasEmoji() && !this._isNative()) {
-      return {
+      cssStyle = {
         backgroundPosition: this.getEmoji().getPosition(),
       }
     }
-    return {}
+    if (emojiSize) {
+      cssStyle = Object.assign(cssStyle, {
+        width: emojiSize + 'px',
+        height: emojiSize + 'px',
+        fontSize: emojiSize * 0.8 + 'px',
+      })
+    }
+    return cssStyle
   }
 
   _content() {

--- a/src/utils/emoji-data.js
+++ b/src/utils/emoji-data.js
@@ -532,6 +532,9 @@ export class EmojiView {
       cssStyle = Object.assign(cssStyle, {
         width: emojiSize + 'px',
         height: emojiSize + 'px',
+        // font-size is used for native emoji which we need
+        // to scale with 0.8 factor to have them look approximately
+        // the same size as image-based emojl.
         fontSize: emojiSize * 0.8 + 'px',
       })
     }

--- a/src/utils/emoji-data.js
+++ b/src/utils/emoji-data.js
@@ -529,14 +529,21 @@ export class EmojiView {
       }
     }
     if (emojiSize) {
-      cssStyle = Object.assign(cssStyle, {
-        width: emojiSize + 'px',
-        height: emojiSize + 'px',
-        // font-size is used for native emoji which we need
-        // to scale with 0.8 factor to have them look approximately
-        // the same size as image-based emojl.
-        fontSize: Math.round(emojiSize * 0.8 * 10) / 10 + 'px',
-      })
+      if (this._isNative()) {
+        // Set font-size for native emoji.
+        cssStyle = Object.assign(cssStyle, {
+          // font-size is used for native emoji which we need
+          // to scale with 0.8 factor to have them look approximately
+          // the same size as image-based emojl.
+          fontSize: Math.round(emojiSize * 0.8 * 10) / 10 + 'px',
+        })
+      } else {
+        // Set width/height for image emoji.
+        cssStyle = Object.assign(cssStyle, {
+          width: emojiSize + 'px',
+          height: emojiSize + 'px',
+        })
+      }
     }
     return cssStyle
   }


### PR DESCRIPTION
The `emojiSize` property controls two things: 

1) the width of the picker 
2) the size of the `span` with emoji (and font-size for native emoji)

The "2" was disabled in [this PR](https://github.com/serebrov/emoji-mart-vue/pull/8) as more HTML to render was one of the reasons that slowed down the picker.

But it is not very convenient: now, to change the emoji size we need to both set the `emojiSize` property and override the CSS.

Now, after some more performance testing, it has shown that adding width/height and font size to the HTML doesn't have a big effect on the performance, so the "2" can be re-enabled.
