### PR TITLE
Fix bundle data path

### DIFF
--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -56,7 +56,10 @@ var config = {
   },
 
   resolve: {
-    extensions: ['.vue', '.js'],
+    extensions: ['.vue', '.js', '.json'],
+    alias: {
+      '../data': path.resolve(__dirname, '../data/'),
+    },
   },
 
   plugins: [

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
         "jest-transform-stub"
     },
     "moduleNameMapper": {
-      ".+\\.css$": "<rootDir>/spec/css-stub.js"
+      ".+\\.css$": "<rootDir>/spec/css-stub.js",
+      "../data/all.json$": "<rootDir>/data/all.json"
     },
     "transformIgnorePatterns": ["^.+\\.css$", "<rootDir>/node_modules/"],
     "collectCoverageFrom": [

--- a/src/components/emoji/emoji.vue
+++ b/src/components/emoji/emoji.vue
@@ -1,5 +1,5 @@
 <script>
-import data from '../../../data/all.json'
+import data from '../data/all.json'
 import { uncompress } from '../../utils/data'
 import { EmojiIndex } from '../../utils/emoji-data'
 import NimbleEmoji from './nimbleEmoji'

--- a/src/components/picker/picker.vue
+++ b/src/components/picker/picker.vue
@@ -1,6 +1,6 @@
 <script>
 
-import data from '../../../data/all.json'
+import data from '../data/all.json'
 import { EmojiIndex } from '../../utils/emoji-data'
 import NimblePicker from './nimblePicker'
 

--- a/src/utils/emoji-data.js
+++ b/src/utils/emoji-data.js
@@ -94,7 +94,7 @@ const SKINS = ['1F3FA', '1F3FB', '1F3FC', '1F3FD', '1F3FE', '1F3FF']
  *
  * Usage:
  *
- *   import data from '../../../data/all.json'
+ *   import data from '../data/all.json'
  *   let index = new EmojiIndex(data)
  *
  */

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -62,7 +62,27 @@ module.exports = Object.assign(
     },
 
     resolve: {
-      extensions: ['.vue', '.js'],
+      extensions: ['.vue', '.js', '.json'],
+      /**
+       * Note: this is a hack to make path to json files same in
+       * the original source and in the bundle.
+       * The bundle is under dist/emoji-mart.js, so to refer the
+       * data files from it, the correct path is '../data/all.json'.
+       * This alias makes data accessible under same path for
+       * unminified sources.
+       *
+       * Before (in the original fork, json files were put into
+       * the bundle, so it was quite bug.
+       * Probably the better solution is to do the same as the
+       * oridinal react project does: it doesn't pack all the code
+       * into the single bundle, it just compiles several versions
+       * of code via babel (dist, dist-es and dist-modern) and
+       * leaves packaging to the application that uses the component.
+       * See https://github.com/missive/emoji-mart/blob/master/package.json.
+       **/
+      alias: {
+        '../data': path.resolve(__dirname, '../data/'),
+      },
     },
 
     plugins: [


### PR DESCRIPTION
The json data was removed from the bundle (marked as "external" for webpack), but this bundle was broken due to that: it tried to include json as "../../../data/all.json" while the bundle is under "dist/emoji-mart.js" and the path to the data from it is "../data/all.json".

This PR adds a path alias, so we can always refer the data as "../data/all.json" (same path as in bundle).