### PR TITLE
Fix window is not defined when using SSR

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -14,6 +14,8 @@ module.exports = Object.assign(
       filename: 'emoji-mart.js',
       library: 'EmojiMart',
       libraryTarget: 'umd',
+      // See https://github.com/webpack/webpack/issues/6784
+      globalObject: "typeof self !== 'undefined' ? self : this",
     },
 
     externals: !TEST && [


### PR DESCRIPTION
When using SSR, the `window is not defined` error is rasied, see #46.

The issue is with webpack (https://github.com/webpack/webpack/issues/6784), it worked in webpack 3 that is used by original `jm-david/emoji-mart-vue` library, but webpack 4 generates a signature with `window` argument.

Applying the fix as suggested in the comment to the webpack issue - use `globalObject: 'typeof self !== \'undefined\' ? self : this'` for output configuration.