### PR TITLE
[#77] wrong active category

### DIFF
--- a/spec/__snapshots__/picker-spec.js.snap
+++ b/spec/__snapshots__/picker-spec.js.snap
@@ -141,8 +141,9 @@ exports[`Picker renders correctly 1`] = `
         />
       </span>
       <span
-        class="emoji-mart-anchor"
+        class="emoji-mart-anchor emoji-mart-anchor-selected"
         data-title="Activity"
+        style="color: rgb(174, 101, 197);"
       >
         <div>
           <svg
@@ -163,9 +164,8 @@ exports[`Picker renders correctly 1`] = `
         />
       </span>
       <span
-        class="emoji-mart-anchor emoji-mart-anchor-selected"
+        class="emoji-mart-anchor"
         data-title="Travel & Places"
-        style="color: rgb(174, 101, 197);"
       >
         <div>
           <svg

--- a/src/components/Picker.vue
+++ b/src/components/Picker.vue
@@ -227,7 +227,11 @@ export default {
       if (this.skipScrollUpdate) {
         this.skipScrollUpdate = false
       } else {
-        this.activeCategory = this.categories[endIndex - 1]
+        // The `endIndex-2` seems to work, but this depends on the internals
+        // of the virtual scroller, I didn't observe it to be less than 0,
+        // but just for the case, we aslo have a fallback to `0` here.
+        let activeIndex = endIndex - 2 > 0 ? endIndex - 2 : 0
+        this.activeCategory = this.categories[activeIndex]
       }
     },
     onAnchorClick(category) {


### PR DESCRIPTION
[#77] Fix: wrong active category (the next category is highlighted as active, not the current one).