### PR TITLE
[#89] improve preview emoji behavior

### DIFF
--- a/docs/app.vue
+++ b/docs/app.vue
@@ -124,6 +124,12 @@
         Show / hide the flags picker (with v-show)
       </button>
     </div>
+
+    <div class="row"></div>
+    <h2>I18n picker example</h2>
+    <div class="row">
+      <Picker emoji="department_store" :data="indexI18n" :i18n="i18n" />
+    </div>
   </div>
 </template>
 
@@ -166,11 +172,42 @@ let indexFiltered = new EmojiIndex(data, {
   },
 })
 
+const i18n = {
+  categories: {
+    search: '搜索结果',
+    recent: '经常使用',
+    smileys: '心情',
+    people: '人物',
+    nature: '动物 & 大自然',
+    foods: '食物 & 饮料',
+    activity: '活动',
+    places: '旅行 & 地标',
+    objects: '物体',
+    symbols: '符号',
+    flags: '国旗',
+    custom: '自定义',
+  },
+}
+
+const indexI18n = new EmojiIndex(data, {
+  exclude: [
+    'flags',
+    'symbols',
+    'objects',
+    'activity',
+    'foods',
+    'people',
+    'places',
+  ],
+})
+
 export default {
   data() {
     return {
       index: index,
       indexFiltered: indexFiltered,
+      indexI18n: indexI18n,
+      i18n: i18n,
       activeSet: 'native',
       emoji: 'point_up',
       title: 'Pick your emoji…',

--- a/spec/picker-spec.js
+++ b/spec/picker-spec.js
@@ -83,6 +83,26 @@ describe('categories', () => {
   })
 })
 
+describe('categories exclude preview emoji', () => {
+  let index = new EmojiIndex(data, {
+    exclude: ['places']
+  })
+  const picker = mount(Picker, {
+    propsData: {
+      data: index,
+    },
+  })
+
+  it('will not throw an error if default emoji is not available', () => {
+    expect(picker.vm.emoji).toEqual('department_store')
+    // When `emoji` (that is emoji id used for idleEmoji) is not available,
+    // like in this case, since we excluded 'places' category that contains
+    // the default `department_store` emoji.
+    // In this case, picker logs en error and uses first emoji available.
+    expect(picker.vm.idleEmoji.id).toEqual('100')
+  })
+})
+
 describe('anchors', () => {
   let index = new EmojiIndex(data, {
     custom: [

--- a/spec/picker-spec.js
+++ b/spec/picker-spec.js
@@ -85,7 +85,7 @@ describe('categories', () => {
 
 describe('categories exclude preview emoji', () => {
   let index = new EmojiIndex(data, {
-    exclude: ['places']
+    exclude: ['places'],
   })
   const picker = mount(Picker, {
     propsData: {

--- a/spec/picker-static-spec.js
+++ b/spec/picker-static-spec.js
@@ -129,7 +129,7 @@ describe('categories', () => {
 
 describe('categories exclude preview emoji', () => {
   let index = new EmojiIndex(data, {
-    exclude: ['places']
+    exclude: ['places'],
   })
   const picker = mount(Picker, {
     propsData: {

--- a/spec/picker-static-spec.js
+++ b/spec/picker-static-spec.js
@@ -127,6 +127,26 @@ describe('categories', () => {
   })
 })
 
+describe('categories exclude preview emoji', () => {
+  let index = new EmojiIndex(data, {
+    exclude: ['places']
+  })
+  const picker = mount(Picker, {
+    propsData: {
+      data: index,
+    },
+  })
+
+  it('will not throw an error if default emoji is not available', () => {
+    expect(picker.vm.emoji).toEqual('department_store')
+    // When `emoji` (that is emoji id used for idleEmoji) is not available,
+    // like in this case, since we excluded 'places' category that contains
+    // the default `department_store` emoji.
+    // In this case, picker logs en error and uses first emoji available.
+    expect(picker.vm.idleEmoji.id).toEqual('100')
+  })
+})
+
 describe('anchors', () => {
   let index = new EmojiIndex(data, {
     custom: [

--- a/src/components/Picker.vue
+++ b/src/components/Picker.vue
@@ -207,7 +207,17 @@ export default {
       return Object.freeze(deepMerge(I18N, this.i18n))
     },
     idleEmoji() {
-      return this.data.emoji(this.emoji)
+      try {
+        return this.data.emoji(this.emoji)
+      } catch (e) {
+        console.error(
+          'Default preview emoji `' +
+            this.emoji +
+            '` is not available, check the Picker `emoji` property',
+        )
+        console.error(e)
+        return this.data.firstEmoji()
+      }
     },
   },
   created() {

--- a/src/components/StaticPicker.vue
+++ b/src/components/StaticPicker.vue
@@ -196,7 +196,17 @@ export default {
       return Object.freeze(deepMerge(I18N, this.i18n))
     },
     idleEmoji() {
-      return this.data.emoji(this.emoji)
+      try {
+        return this.data.emoji(this.emoji)
+      } catch (e) {
+        console.error(
+          'Default preview emoji `' +
+            this.emoji +
+            '` is not available, check the Picker `emoji` property',
+        )
+        console.error(e)
+        return this.data.firstEmoji()
+      }
     },
   },
   created() {

--- a/src/utils/emoji-data.js
+++ b/src/utils/emoji-data.js
@@ -247,6 +247,14 @@ export class EmojiIndex {
     return emoji
   }
 
+  firstEmoji() {
+    let emoji = this._emojis[Object.keys(this._emojis)[0]]
+    if (!emoji) {
+      throw new Error('Can not get first emoji')
+    }
+    return emoji
+  }
+
   hasEmoji(emojiId) {
     if (this._data.aliases.hasOwnProperty(emojiId)) {
       emojiId = this._data.aliases[emojiId]


### PR DESCRIPTION
[#89] improve preview emoji behavior: log a more explanatory message into the console, use the first emoji available.
This should be more user friendly, as it will be easy to see that first emoji in the UI and change the settings if needed.