### PR TITLE
Populate default emojis in frequently used more sensible

### DIFF
--- a/src/utils/frequently.js
+++ b/src/utils/frequently.js
@@ -48,7 +48,7 @@ function get(maxNumber) {
 
     let defaultLength = Math.min(maxNumber, DEFAULTS.length)
     for (let i = 0; i < defaultLength; i++) {
-      defaults[DEFAULTS[i]] = defaultLength - i
+      defaults[DEFAULTS[i]] = parseInt((defaultLength - i) / 4, 10) + 1
       result.push(DEFAULTS[i])
     }
 


### PR DESCRIPTION
For more context/background see https://github.com/nextcloud/nextcloud-vue/issues/2360

### Before
```json
{
  "+1": 16,
  "grinning": 15,
  "kissing_heart": 14,
  "heart_eyes": 13,
  "laughing": 12,
  "stuck_out_tongue_winking_eye": 11,
  "sweat_smile": 10,
  "joy": 9,
  "scream": 8,
  "disappointed": 7,
  "unamused": 6,
  "weary": 5,
  "sob": 4,
  "sunglasses": 3,
  "heart": 2,
  "poop": 1,
}
```
### After
```json
{
  "+1": 5,
  "grinning": 4,
  "kissing_heart": 4,
  "heart_eyes": 4,
  "laughing": 4,
  "stuck_out_tongue_winking_eye": 3,
  "sweat_smile": 3,
  "joy": 3,
  "scream": 3,
  "disappointed": 2,
  "unamused": 2,
  "weary": 2,
  "sob": 2,
  "sunglasses": 1,
  "heart": 1,
  "poop": 1,
}
```