### PR TITLE
[#152]. Fix the issue with duplicate :hankey: emoji.

### DIFF
--- a/spec/frequently-spec.js
+++ b/spec/frequently-spec.js
@@ -76,7 +76,7 @@ describe('Picker frequnt category', () => {
         sob: 2,
         sunglasses: 1,
         heart: 1,
-        poop: 1,
+        hankey: 1,
         nerd_face: 25,
         space_invader: 24,
         robot_face: 23,

--- a/src/utils/frequently.js
+++ b/src/utils/frequently.js
@@ -16,7 +16,7 @@ const DEFAULTS = [
   'sob',
   'sunglasses',
   'heart',
-  'poop',
+  'hankey',
 ]
 
 let frequently, initialized


### PR DESCRIPTION
[#152]. Fix the issue with duplicate :hankey: emoji in the frequently used emojis list.