### PR TITLE
feat: add type="button" to button in anchors to prevent unintended form submission

### DIFF
--- a/src/components/anchors.vue
+++ b/src/components/anchors.vue
@@ -3,6 +3,7 @@
     <button
       v-for="category in categories"
       role="tab"
+      type="button"
       :aria-label="category.name"
       :aria-selected="category.id == activeCategory.id"
       :key="category.id"


### PR DESCRIPTION
Thanks, for this awesome library!

When it is used in `<form>`, the anchor dispatches `submit` event because `type="button"` attribute is not set.
So the form can be accidentally submitted.

This PR fixes this behavior.