### PR TITLE
[#204] Fix on click double trigger in Vue 3.

### DIFF
--- a/src/components/Emoji.vue
+++ b/src/components/Emoji.vue
@@ -28,6 +28,7 @@ export default {
       required: true,
     },
   },
+  emits: ["click"],
   computed: {
     view() {
       return new EmojiView(


### PR DESCRIPTION
[#204] Fix on click double trigger in Vue 3.

I reproduced this issue in the [vue3 demo project](https://github.com/serebrov/emoji-mart-vue3-demo/commit/6e559709834f8ba1e991dcda3b7a29e097ed5b01), the click handler invoked twice, first with emoji object and second time with `PointerEvent` object.

Related discussion: https://github.com/vuejs/core/issues/813

Adding `emits: ["click"]` to the component definition seems to help and vue 2 project works with this change too.