### PR TITLE
[#264] Prevent input 'select' event from propagating to component.

### DIFF
--- a/spec/search-spec.js
+++ b/spec/search-spec.js
@@ -74,6 +74,19 @@ describe('search', () => {
     // Category does not change when the search is active.
     expect(anchors.vm.activeCategory.id).toBe('recent')
   })
+
+  it('the text select event is not propagated', () => {
+    // Note: the issue related to this test is not reproduced in Vue 2,
+    // so I am not sure if the test really works (if we remove the fix,
+    // the test will still pass).
+    let search = picker.findComponent(Search)
+    let input = search.find('input')
+    input.element.value = 'zxcvb'
+    input.trigger('select')
+
+    let events = picker.emitted().select
+    expect(events).toBeUndefined()
+  })
 })
 
 describe('search no focus', () => {

--- a/src/components/Picker.vue
+++ b/src/components/Picker.vue
@@ -31,6 +31,7 @@
         @arrowDown="onArrowDown"
         @arrowUp="onArrowUp"
         @enter="onEnter"
+        @select="onTextSelect"
       />
     </slot>
 
@@ -236,6 +237,13 @@ export default {
     onEmojiClick(emoji) {
       this.$emit('select', emoji)
       frequently.add(emoji)
+    },
+    onTextSelect($event) {
+      // Prevent default text select event.
+      // In Vue 3 it goes through the component and triggers the `select`
+      // event that is supposed to be emmited only with emoji.
+      // (there is no such problem in Vue 2).
+      $event.stopPropagation()
     },
     onSkinChange(skin) {
       this.activeSkin = skin


### PR DESCRIPTION
Prevent default text select event.

In Vue 3 the event goes through the component and triggers the `select` event that is supposed to be emitted only with emoji (there is no such problem in Vue 2).
