### PR TITLE
fix(Picker): Watch for `skin` property changes

### DIFF
--- a/src/components/Picker.vue
+++ b/src/components/Picker.vue
@@ -190,6 +190,11 @@ export default {
       }
     },
   },
+  watch: {
+    skin() {
+      this.onSkinChange(this.skin)
+    },
+  },
   methods: {
     onScroll() {
       if (this.infiniteScroll && !this.waitingForPaint) {


### PR DESCRIPTION
Currently changes of properties, especially the `skin` prop, are not reactive.
Meaning you have to close and reload the picker if you change the prop.

So this watches on the prop so that you can modify it and the picker will react (e.g. we want to have the skin tone selector next to the search). Which works and looks like this for us:


https://github.com/serebrov/emoji-mart-vue/assets/1855448/ca8350f4-df24-4c6c-84f1-d4ab6ae2be34

