### PR TITLE
fix: declare all emits in all components

### DIFF
--- a/src/components/Picker.vue
+++ b/src/components/Picker.vue
@@ -130,6 +130,7 @@ export default {
       required: true,
     },
   },
+  emits: ['select', 'skin-change'],
   data() {
     return {
       activeSkin: this.skin || store.get('skin') || this.defaultSkin,

--- a/src/components/anchors.vue
+++ b/src/components/anchors.vue
@@ -48,6 +48,7 @@ export default {
       },
     },
   },
+  emits: ['click'],
   created() {
     this.svgs = svgs
   },

--- a/src/components/search.vue
+++ b/src/components/search.vue
@@ -62,6 +62,7 @@ export default {
       required: false,
     },
   },
+  emits: ['search', 'enter', 'arrowUp', 'arrowDown', 'arrowRight', 'arrowLeft'],
   data() {
     return {
       value: '',

--- a/src/components/skins.vue
+++ b/src/components/skins.vue
@@ -17,6 +17,7 @@ export default {
       required: true
     }
   },
+  emits: ['change'],
   data() {
     return {
       opened: false


### PR DESCRIPTION
This is the same as https://github.com/serebrov/emoji-mart-vue/pull/243 but in the other places that were not covered there.

We encountered this in Safari 17.4.1 where the categories would change on Vue click event correctly but right after that the native click with ClickEvent object as it's first argument would be processed and make the picker completely empty with no way back.