### PR TITLE
fix(picker): show results while infinite scroll is disabled

### DIFF
--- a/src/components/Picker.vue
+++ b/src/components/Picker.vue
@@ -51,7 +51,7 @@
 
         <category
           v-for="(category, idx) in view.filteredCategories"
-          v-show="infiniteScroll || category == view.activeCategory"
+          v-show="infiniteScroll || category == view.activeCategory || isSearching"
           :ref="'categories_' + idx"
           :key="category.id"
           :data="data"
@@ -189,6 +189,9 @@ export default {
         console.error(e)
         return this.data.firstEmoji()
       }
+    },
+    isSearching() {
+      return this.view.searchEmojis != null;
     },
   },
   watch: {


### PR DESCRIPTION
I encountered that if you are searching emojis while infinite scrolling is disabled in won't show the results.