### PR TITLE
Fix category switch to clear search

### DIFF
--- a/spec/picker-spec.js
+++ b/spec/picker-spec.js
@@ -85,6 +85,37 @@ describe('Picker', () => {
       })
     })
   })
+
+  it('clears search when switching categories', (done) => {
+    let search = picker.findComponent(Search)
+    let input = search.find('input')
+    input.element.value = '+1'
+    input.trigger('input')
+
+    picker.vm.$nextTick(() => {
+      let categories = picker.findAllComponents(Category)
+      let searchCategory = categories.at(0)
+      expect(searchCategory.vm.id).toBe('search')
+
+      let anchors = picker.findComponent(Anchors)
+      let anchorsCategories = anchors.findAll('.emoji-mart-anchor')
+      let symbols = anchorsCategories.at(8)
+      expect(symbols.element.attributes['data-title'].value).toBe('Symbols')
+      symbols.trigger('click')
+
+      picker.vm.$nextTick(() => {
+        let events = anchors.emitted().click
+        let category = events[0][0]
+        expect(category.id).toBe('symbols')
+        expect(anchors.vm.activeCategory.id).toBe('symbols')
+
+        // Verify that the search input is cleared
+        expect(search.vm.value).toBe('')
+
+        done()
+      })
+    })
+  })
 })
 
 describe('categories', () => {

--- a/src/components/Picker.vue
+++ b/src/components/Picker.vue
@@ -212,6 +212,10 @@ export default {
     },
     onAnchorClick(category) {
       this.view.onAnchorClick(category)
+      // Clear the search when switching categories
+      // otherwise categories switch does not work.
+      // See #136.
+      this.$refs.search.clear()
     },
     onSearch(value) {
       this.view.onSearch(value)


### PR DESCRIPTION
Related to #136

Clear the search when switching categories in the emoji picker.

Generated with copilot, need to test locally and review test more thoroughly, make sure it works and verifies the fix.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/serebrov/emoji-mart-vue/issues/136?shareId=XXXX-XXXX-XXXX-XXXX).